### PR TITLE
Bugfix/delete job return 404 when no job #43

### DIFF
--- a/piezo_web_app/PiezoWebApp/src/handlers/delete_job.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/delete_job.py
@@ -20,5 +20,7 @@ class DeleteJobHandler(BaseHandler):
         namespace = self.get_body_attribute('namespace', required=True)
         self._logger.debug(f'Trying to delete job "{job_name}" in namespace "{namespace}".')
         result = self._spark_job_service.delete_job(job_name, namespace)
-        self._logger.debug(f'Deleting job "{job_name}" in namespace "{namespace}" returned result "{result}".')
+        self._logger.debug(f'Deleting job "{job_name}" in namespace "{namespace}" returned result "{result["status"]}".')
+        self.check_request_was_completed_successfully(result)
+        del result['status']
         return result

--- a/piezo_web_app/PiezoWebApp/src/handlers/delete_job.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/delete_job.py
@@ -20,7 +20,9 @@ class DeleteJobHandler(BaseHandler):
         namespace = self.get_body_attribute('namespace', required=True)
         self._logger.debug(f'Trying to delete job "{job_name}" in namespace "{namespace}".')
         result = self._spark_job_service.delete_job(job_name, namespace)
-        self._logger.debug(f'Deleting job "{job_name}" in namespace "{namespace}" returned result "{result["status"]}".')
+        self._logger.debug(
+            f'Deleting job "{job_name}" in namespace "{namespace}" returned result "{result["status"]}".'
+        )
         self.check_request_was_completed_successfully(result)
         del result['status']
         return result

--- a/piezo_web_app/PiezoWebApp/src/handlers/get_logs.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/get_logs.py
@@ -19,6 +19,9 @@ class GetLogsHandler(BaseHandler):
         namespace = self.get_body_attribute('namespace', required=True)
         self._logger.debug(f'Trying to delete driver "{driver_name}" in namespace "{namespace}".')
         result = self._spark_job_service.get_logs(driver_name, namespace)
-        self._logger.debug(f'Getting logs from driver "{driver_name}" in namespace "{namespace}" '
-                           f'returned result "{result}".')
+        self._logger.debug(
+            f'Getting logs from driver "{driver_name}" in namespace "{namespace}" returned result "{result["status"]}".'
+        )
+        self.check_request_was_completed_successfully(result)
+        del result['status']
         return result

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -47,12 +47,18 @@ class SparkJobService(ISparkJobService):
     def get_logs(self, driver_name, namespace):
         try:
             api_response = self._connection.read_namespaced_pod_log(driver_name, namespace)
-            return api_response
+            return {
+                'message': api_response,
+                'status': StatusCodes.Okay.value
+            }
         except ApiException as exception:
             message = f'Kubernetes error when trying to get logs for driver "{driver_name}" in namespace '\
                 f'"{namespace}": {exception.reason}'
             self._logger.error(message)
-            return message
+            return {
+                'message': message,
+                'status': exception.status
+            }
 
     def submit_job(self, body):
         # Validate the body keys

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -31,12 +31,18 @@ class SparkJobService(ISparkJobService):
                 job_name,
                 body
             )
-            return api_response.content
+            return {
+                'message': api_response.content,
+                'status': StatusCodes.Okay.value
+            }
         except ApiException as exception:
             message = f'Kubernetes error when trying to delete job "{job_name}" in namespace '\
                 f'"{namespace}": {exception.reason}'
             self._logger.error(message)
-            return message
+            return {
+                'status': exception.status,
+                'message': message
+            }
 
     def get_logs(self, driver_name, namespace):
         try:

--- a/piezo_web_app/PiezoWebApp/tests/handlers/get_logs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/get_logs_test.py
@@ -28,16 +28,22 @@ class TestGetLogsHandler(BaseHandlerTest):
     def test_get_returns_logs_when_successful(self):
         # Arrange
         body = {'driver_name': 'test-driver', 'namespace': 'test-namespace'}
-        self.mock_spark_job_service.get_logs.return_value = '{"log": "success"}'
+        self.mock_spark_job_service.get_logs.return_value = {
+            "message": "logs",
+            "status": 200
+        }
         # Act
         response_body, response_code = yield self.send_request(body)
         # Assert
         self.mock_spark_job_service.get_logs.assert_called_once_with('test-driver', 'test-namespace')
         self.mock_logger.debug.assert_has_calls([
             call('Trying to delete driver "test-driver" in namespace "test-namespace".'),
-            call('Getting logs from driver "test-driver" in namespace "test-namespace" returned result '
-                 '"{"log": "success"}".')
+            call('Getting logs from driver "test-driver" in namespace "test-namespace" returned result "200".')
         ])
         assert response_code == 200
-        assert response_body['status'] == 'success'
-        assert response_body['data'] == '{"log": "success"}'
+        self.assertDictEqual(response_body, {
+            'status': 'success',
+            'data': {
+                'message': 'logs'
+            }
+        })

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -47,7 +47,7 @@ class TestSparkJobService(TestCase):
         # Act
         result = self.test_service.delete_job('test-spark-job', 'test-namespace')
         # Assert
-        assert result == "Response"
+        self.assertDictEqual(result, {'message': 'Response', 'status': 200})
         self.mock_kubernetes_adapter.delete_namespaced_custom_object.assert_called_once_with(
             CRD_GROUP,
             CRD_VERSION,
@@ -59,14 +59,15 @@ class TestSparkJobService(TestCase):
 
     def test_delete_job_logs_and_returns_api_exception_reason(self):
         # Arrange
-        self.mock_kubernetes_adapter.delete_namespaced_custom_object.side_effect = ApiException(reason="Reason")
+        self.mock_kubernetes_adapter.delete_namespaced_custom_object.side_effect = ApiException(reason="Reason", status=101)
         # Act
         result = self.test_service.delete_job('test-spark-job', 'test-namespace')
         # Assert
         expected_message = \
             'Kubernetes error when trying to delete job "test-spark-job" in namespace "test-namespace": Reason'
         self.mock_logger.error.assert_called_once_with(expected_message)
-        assert result == expected_message
+        assert result['status'] == 101
+        assert result['message'] == expected_message
 
     def test_get_logs_sends_expected_arguments(self):
         # Arrange

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -59,7 +59,10 @@ class TestSparkJobService(TestCase):
 
     def test_delete_job_logs_and_returns_api_exception_reason(self):
         # Arrange
-        self.mock_kubernetes_adapter.delete_namespaced_custom_object.side_effect = ApiException(reason="Reason", status=101)
+        self.mock_kubernetes_adapter.delete_namespaced_custom_object.side_effect = ApiException(
+            reason="Reason",
+            status=101
+        )
         # Act
         result = self.test_service.delete_job('test-spark-job', 'test-namespace')
         # Assert

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -61,7 +61,7 @@ class TestSparkJobService(TestCase):
         # Arrange
         self.mock_kubernetes_adapter.delete_namespaced_custom_object.side_effect = ApiException(
             reason="Reason",
-            status=101
+            status=999
         )
         # Act
         result = self.test_service.delete_job('test-spark-job', 'test-namespace')
@@ -69,7 +69,7 @@ class TestSparkJobService(TestCase):
         expected_message = \
             'Kubernetes error when trying to delete job "test-spark-job" in namespace "test-namespace": Reason'
         self.mock_logger.error.assert_called_once_with(expected_message)
-        assert result['status'] == 101
+        assert result['status'] == 999
         assert result['message'] == expected_message
 
     def test_get_logs_sends_expected_arguments(self):
@@ -83,7 +83,7 @@ class TestSparkJobService(TestCase):
 
     def test_get_logs_logs_and_returns_api_exception_reason(self):
         # Arrange
-        self.mock_kubernetes_adapter.read_namespaced_pod_log.side_effect = ApiException(reason="Reason", status=101)
+        self.mock_kubernetes_adapter.read_namespaced_pod_log.side_effect = ApiException(reason="Reason", status=999)
         # Act
         result = self.test_service.get_logs('test-driver', 'test-namespace')
         # Assert
@@ -91,7 +91,7 @@ class TestSparkJobService(TestCase):
             'Kubernetes error when trying to get logs for driver "test-driver" in namespace "test-namespace": Reason'
         self.mock_logger.error.assert_called_once_with(expected_message)
         self.assertDictEqual(result, {
-            'status': 101,
+            'status': 999,
             'message': 'Kubernetes error when trying to get logs for driver "test-driver" '
                        'in namespace "test-namespace": Reason'
         })
@@ -181,7 +181,7 @@ class TestSparkJobService(TestCase):
             }
         }
         self.mock_kubernetes_adapter.create_namespaced_custom_object.side_effect = \
-            ApiException(reason="Reason", status=101)
+            ApiException(reason="Reason", status=999)
         # Act
         result = self.test_service.submit_job(body)
         # Assert
@@ -197,6 +197,6 @@ class TestSparkJobService(TestCase):
             })
         ])
         self.assertDictEqual(result, {
-            'status': 101,
+            'status': 999,
             'message': expected_message
         })


### PR DESCRIPTION
Responses from the `delete_job` and  `get_logs` methods of the Spark service are consistent with the response from the `submit_job` method. The respective handlers pass on the status code from the Kubernetes adapter if there is an error.