### PR TITLE
Feature/check status of job#46

### DIFF
--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -28,9 +28,9 @@ Get Driver Name
     ${driver_name}=   Catenate    SEPARATOR=    ${job_name}   -driver
     [return]    ${driver_name}
 
-Get Logs From Spark Driver
-    [Arguments]   ${driver_name}
-    ${body}=    Create Dictionary   driver_name=${driver_name}   namespace=default
+Get Logs For Spark Job
+    [Arguments]   ${job_name}
+    ${body}=    Create Dictionary   job_name=${job_name}   namespace=default
     ${response}=  Get Request With Json Body   /piezo/getlogs    ${body}
     [return]    ${response}
 
@@ -47,6 +47,13 @@ Get Request With Json Body
     ${response}=  Get Request   k8s   ${route}    headers=${headers}    json=${body}
     [return]  ${response}
 
+Get Status Of Spark Job
+    [Arguments]   ${job_name}
+    ${body}=    Create Dictionary   job_name=${job_name}   namespace=default
+    ${response}=  Get Request With Json Body   /piezo/jobstatus    ${body}
+    [return]    ${response}
+
+
 Post Request With Json Body
     [Arguments]   ${route}    ${body}
     ${headers}=   Json Header
@@ -59,9 +66,3 @@ Submit SparkPi Job
     ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.SparkPi    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
     [return]  ${response}
-
-Get Status Of Spark Job
-    [Arguments] ${job_name}
-    ${body}=    Create Dictionary job_name=${job_name} namespace=default
-    ${response}=    Get Request With Json Body /piezo/jobstatus $body
-    [return]    ${response}

--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -59,3 +59,9 @@ Submit SparkPi Job
     ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.SparkPi    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
     [return]  ${response}
+
+Get Status Of Spark Job
+    [Arguments] ${job_name}
+    ${body}=    Create Dictionary job_name=${job_name} namespace=default
+    ${response}=    Get Request With Json Body /piezo/jobstatus $body
+    [return]    ${response}

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -67,4 +67,4 @@ Can Get Status Of Submitted Spark Job
     ${response}=  Get Status Of Spark Job   ${job_name}
     Confirm Ok Response     ${response}
     ${data}=  Get Response Data     ${response}
-    Should Be Equal As String       ${data["message"]}        Completed
+    Should Be Equal As Strings       ${data["message"]}        COMPLETED

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -25,7 +25,11 @@ Piezo Heartbeat Returns Ok Response
     Dictionaries Should Be Equal    ${data}   ${expected}
 
 Get Logs Of Non Job Returns Not Found Response
-    ${response}=  Get Logs From Spark Driver    dummy
+    ${response}=  Get Logs For Spark Job    dummy
+    Confirm Not Found Response  ${response}
+
+Get Status Of Non Job Returns Not Found Response
+    ${response}=  Get Status Of Spark Job    dummy
     Confirm Not Found Response  ${response}
 
 Delete Job Of Non Job Returns Not Found Response
@@ -41,25 +45,26 @@ Submit Spark Pi Job Returns Ok Response
 
 Can Get Logs Of Submitted Spark Job
     ${job_name}=     Set Variable   spark-pi-fe244
-    ${driver_name}=   Get Driver Name   ${job_name}
     Submit SparkPi Job    ${job_name}
     Sleep   1 minute
-    ${response}=  Get Logs From Spark Driver    ${driver_name}
+    ${response}=  Get Logs For Spark Job    ${job_name}
     ${joblog}=    Get Response Data Message   ${response}
     ${pi_lines}=    Get Lines Containing String   ${joblog}   Pi is roughly 3
     ${num_pi_lines}=    Get Line Count    ${pi_lines}
     Should Be Equal As Integers   ${num_pi_lines}   1
 
 Can Delete Submitted Spark Job
-    Submit SparkPi Job    spark-pi-83783
+    ${job_name}=    Set Variable        spark-pi-83783
+    Submit SparkPi Job   ${job_name}
     Sleep   1 minute
     ${response}=  Delete Spark Job    ${job_name}
     Confirm Ok Response   ${response}
 
 Can Get Status Of Submitted Spark Job
-    Submit SparkPi Job    spark-pi-5jk23s
+    ${job_name}=     Set Variable       spark-pi-5jk23s
+    Submit SparkPi Job    ${job_name}
     Sleep   1 minute
-    ${response}=  Get Status Of Spark Job ${job_name}
-    Confirm Ok Response ${response}
-    ${data}= Get Response Data ${response}
-    Should Be Equal As String ${data["message"]} Completed
+    ${response}=  Get Status Of Spark Job   ${job_name}
+    Confirm Ok Response     ${response}
+    ${data}=  Get Response Data     ${response}
+    Should Be Equal As String       ${data["message"]}        Completed

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -55,3 +55,11 @@ Can Delete Submitted Spark Job
     Sleep   1 minute
     ${response}=  Delete Spark Job    ${job_name}
     Confirm Ok Response   ${response}
+
+Can Get Status Of Submitted Spark Job
+    Submit SparkPi Job    spark-pi-5jk23s
+    Sleep   1 minute
+    ${response}=  Get Status Of Spark Job ${job_name}
+    Confirm Ok Response ${response}
+    ${data}= Get Response Data ${response}
+    Should Be Equal As String ${data["message"]} Completed

--- a/piezo_web_app/PiezoWebApp/run_piezo.py
+++ b/piezo_web_app/PiezoWebApp/run_piezo.py
@@ -71,8 +71,9 @@ def build_app(container, use_route_stem=False):
             (heartbeat_route, HeartbeatHandler),
             (format_route_specification(route_stem + 'deletejob'), DeleteJobHandler, container),
             (format_route_specification(route_stem + 'getlogs'), GetLogsHandler, container),
-            (format_route_specification(route_stem + 'submitjob'), SubmitJobHandler, container),
-            (format_route_specification(route_stem + 'jobstatus'), JobStatusHandler, container)
+            (format_route_specification(route_stem + 'jobstatus'), JobStatusHandler, container),
+            (format_route_specification(route_stem + 'submitjob'), SubmitJobHandler, container)
+
         ]
     )
     return app

--- a/piezo_web_app/PiezoWebApp/run_piezo.py
+++ b/piezo_web_app/PiezoWebApp/run_piezo.py
@@ -10,6 +10,7 @@ from PiezoWebApp.src.handlers.delete_job import DeleteJobHandler
 from PiezoWebApp.src.handlers.get_logs import GetLogsHandler
 from PiezoWebApp.src.handlers.heartbeat_handler import HeartbeatHandler
 from PiezoWebApp.src.handlers.submit_job import SubmitJobHandler
+from PiezoWebApp.src.handlers.job_status import JobStatusHandler
 from PiezoWebApp.src.services.kubernetes.kubernetes_adapter import KubernetesAdapter
 from PiezoWebApp.src.services.spark_job.validation.manifest_populator import ManifestPopulator
 from PiezoWebApp.src.services.spark_job.validation.validation_ruleset import ValidationRuleset
@@ -70,7 +71,8 @@ def build_app(container, use_route_stem=False):
             (heartbeat_route, HeartbeatHandler),
             (format_route_specification(route_stem + 'deletejob'), DeleteJobHandler, container),
             (format_route_specification(route_stem + 'getlogs'), GetLogsHandler, container),
-            (format_route_specification(route_stem + 'submitjob'), SubmitJobHandler, container)
+            (format_route_specification(route_stem + 'submitjob'), SubmitJobHandler, container),
+            (format_route_specification(route_stem + 'jobstatus'), JobStatusHandler, container)
         ]
     )
     return app

--- a/piezo_web_app/PiezoWebApp/src/handlers/get_logs.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/get_logs.py
@@ -8,19 +8,19 @@ from PiezoWebApp.src.handlers.schema.schema_helpers import create_object_schema_
 class GetLogsHandler(BaseHandler):
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(
-            ['driver_name', 'namespace'], required=['driver_name', 'namespace']),
+            ['job_name', 'namespace'], required=['job_name', 'namespace']),
         input_example={
-            'driver_name': 'example-driver',
+            'job_name': 'example-job',
             'namespace': 'default'
         }
     )
     def get(self, *args, **kwargs):
-        driver_name = self.get_body_attribute('driver_name', required=True)
+        job_name = self.get_body_attribute('job_name', required=True)
         namespace = self.get_body_attribute('namespace', required=True)
-        self._logger.debug(f'Trying to delete driver "{driver_name}" in namespace "{namespace}".')
-        result = self._spark_job_service.get_logs(driver_name, namespace)
+        self._logger.debug(f'Trying to get logs from spark job "{job_name}" in namespace "{namespace}".')
+        result = self._spark_job_service.get_logs(job_name, namespace)
         self._logger.debug(
-            f'Getting logs from driver "{driver_name}" in namespace "{namespace}" returned result "{result["status"]}".'
+            f'Getting logs from spark job "{job_name}" in namespace "{namespace}" returned result "{result["status"]}".'
         )
         self.check_request_was_completed_successfully(result)
         del result['status']

--- a/piezo_web_app/PiezoWebApp/src/handlers/job_status.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/job_status.py
@@ -8,14 +8,14 @@ from PiezoWebApp.src.handlers.schema.schema_helpers import create_object_schema_
 class JobStatusHandler(BaseHandler):
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(
-            ['spark_job', 'namespace'], required=['spark_job', 'namespace']),
+            ['job_name', 'namespace'], required=['job_name', 'namespace']),
         input_example={
-            'spark_job': 'example-driver',
+            'job_name': 'example-driver',
             'namespace': 'default'
         }
     )
     def get(self, *args, **kwargs):
-        spark_job = self.get_body_attribute('spark_job', required=True)
+        spark_job = self.get_body_attribute('job_name', required=True)
         namespace = self.get_body_attribute('namespace', required=True)
         self._logger.debug(f'Trying to get status of spark job "{spark_job}" in namespace "{namespace}".')
         result = self._spark_job_service.get_job_status(spark_job, namespace)

--- a/piezo_web_app/PiezoWebApp/src/handlers/job_status.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/job_status.py
@@ -1,0 +1,28 @@
+from tornado_json import schema
+
+from PiezoWebApp.src.handlers.base_handler import BaseHandler
+from PiezoWebApp.src.handlers.schema.schema_helpers import create_object_schema_with_string_properties
+
+
+# pylint: disable=abstract-method
+class JobStatusHandler(BaseHandler):
+    @schema.validate(
+        input_schema=create_object_schema_with_string_properties(
+            ['driver_name', 'namespace'], required=['driver_name', 'namespace']),
+        input_example={
+            'driver_name': 'example-driver',
+            'namespace': 'default'
+        }
+    )
+    def get(self, *args, **kwargs):
+        driver_name = self.get_body_attribute('driver_name', required=True)
+        namespace = self.get_body_attribute('namespace', required=True)
+        self._logger.debug(f'Trying to get status of job with driver "{driver_name}" in namespace "{namespace}".')
+        result = self._spark_job_service.get_job_status(driver_name, namespace)
+        self._logger.debug(
+            f'Getting status of job with driver "{driver_name}" in namespace "{namespace}" returned '
+            f'result "{result["status"]}".'
+        )
+        self.check_request_was_completed_successfully(result)
+        del result['status']
+        return result

--- a/piezo_web_app/PiezoWebApp/src/handlers/job_status.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/job_status.py
@@ -8,19 +8,19 @@ from PiezoWebApp.src.handlers.schema.schema_helpers import create_object_schema_
 class JobStatusHandler(BaseHandler):
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(
-            ['driver_name', 'namespace'], required=['driver_name', 'namespace']),
+            ['spark_job', 'namespace'], required=['spark_job', 'namespace']),
         input_example={
-            'driver_name': 'example-driver',
+            'spark_job': 'example-driver',
             'namespace': 'default'
         }
     )
     def get(self, *args, **kwargs):
-        driver_name = self.get_body_attribute('driver_name', required=True)
+        spark_job = self.get_body_attribute('spark_job', required=True)
         namespace = self.get_body_attribute('namespace', required=True)
-        self._logger.debug(f'Trying to get status of job with driver "{driver_name}" in namespace "{namespace}".')
-        result = self._spark_job_service.get_job_status(driver_name, namespace)
+        self._logger.debug(f'Trying to get status of spark job "{spark_job}" in namespace "{namespace}".')
+        result = self._spark_job_service.get_job_status(spark_job, namespace)
         self._logger.debug(
-            f'Getting status of job with driver "{driver_name}" in namespace "{namespace}" returned '
+            f'Getting status of spark job "{spark_job}" in namespace "{namespace}" returned '
             f'result "{result["status"]}".'
         )
         self.check_request_was_completed_successfully(result)

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
@@ -20,3 +20,7 @@ class IKubernetesAdapter(metaclass=ABCMeta):
     @abstractmethod
     def create_namespaced_custom_object(self, group, version, namespace, plural, body):
         pass
+
+    @abstractmethod
+    def get_namespaced_custom_object_status(self, group, version, namespace, plural, name):
+        pass

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
@@ -22,5 +22,5 @@ class IKubernetesAdapter(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_namespaced_custom_object_status(self, group, version, namespace, plural, name):
+    def get_namespaced_custom_object(self, group, version, namespace, plural, name):
         pass

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
@@ -22,3 +22,7 @@ class KubernetesAdapter(IKubernetesAdapter):
     # pylint: disable=too-many-arguments
     def create_namespaced_custom_object(self, group, version, namespace, plural, body):
         return self._custom_connection.create_namespaced_custom_object(group, version, namespace, plural, body)
+
+    def get_namespaced_custom_object_status(self, group, version, namespace, plural, name):
+        return \
+            self._custom_connection.get_namespaced_custom_object_status(self, group, version, namespace, plural, name)

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
@@ -23,6 +23,5 @@ class KubernetesAdapter(IKubernetesAdapter):
     def create_namespaced_custom_object(self, group, version, namespace, plural, body):
         return self._custom_connection.create_namespaced_custom_object(group, version, namespace, plural, body)
 
-    def get_namespaced_custom_object_status(self, group, version, namespace, plural, name):
-        return \
-            self._custom_connection.get_namespaced_custom_object_status(group, version, namespace, plural, name)
+    def get_namespaced_custom_object(self, group, version, namespace, plural, name):
+        return self._custom_connection.get_namespaced_custom_object(group, version, namespace, plural, name)

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
@@ -25,4 +25,4 @@ class KubernetesAdapter(IKubernetesAdapter):
 
     def get_namespaced_custom_object_status(self, group, version, namespace, plural, name):
         return \
-            self._custom_connection.get_namespaced_custom_object_status(self, group, version, namespace, plural, name)
+            self._custom_connection.get_namespaced_custom_object_status(group, version, namespace, plural, name)

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
@@ -8,7 +8,7 @@ class ISparkJobService(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_job_status(self, job_driver_name, namespace):
+    def get_job_status(self, job_name, namespace):
         pass
 
     @abstractmethod

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
@@ -8,7 +8,7 @@ class ISparkJobService(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_job_status(self, job_name, namespace):
+    def get_job_status(self, job_driver_name, namespace):
         pass
 
     @abstractmethod

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
@@ -8,6 +8,10 @@ class ISparkJobService(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def get_job_status(self, job_name, namespace):
+        pass
+
+    @abstractmethod
     def get_logs(self, driver_name, namespace):
         pass
 

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -44,19 +44,22 @@ class SparkJobService(ISparkJobService):
                 'message': message
             }
 
-    def get_job_status(self, job_name, namespace):
+    def get_job_status(self, job_driver_name, namespace):
         try:
             api_response = self._connection.get_namespaced_custom_object_status(
                 CRD_GROUP,
                 CRD_VERSION,
                 namespace,
                 CRD_PLURAL,
-                job_name,
+                job_driver_name
             )
-            return api_response
+            return {
+                'message': api_response,
+                'status': StatusCodes.Okay.value
+            }
         except ApiException as exception:
-            message = f'Kubernetes error when trying to get status of job "{job_name}" in namespace ' \
-                      f'"{namespace}": {exception.reason}'
+            message = f'Kubernetes error when trying to get status of job with driver "{job_driver_name}" in ' \
+                      f'namespace "{namespace}": {exception.reason}'
             self._logger.error(message)
             return {
                 'status': exception.status,

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -59,7 +59,7 @@ class SparkJobService(ISparkJobService):
                 'status': StatusCodes.Okay.value
             }
         except ApiException as exception:
-            message = f'Kubernetes error when trying to get status of job "{job_name}" in ' \
+            message = f'Kubernetes error when trying to get status of spark job "{job_name}" in ' \
                       f'namespace "{namespace}": {exception.reason}'
             self._logger.error(message)
             return {

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -44,6 +44,25 @@ class SparkJobService(ISparkJobService):
                 'message': message
             }
 
+    def get_job_status(self, job_name, namespace):
+        try:
+            api_response = self._connection.get_namespaced_custom_object_status(
+                CRD_GROUP,
+                CRD_VERSION,
+                namespace,
+                CRD_PLURAL,
+                job_name,
+            )
+            return api_response
+        except ApiException as exception:
+            message = f'Kubernetes error when trying to get status of job "{job_name}" in namespace ' \
+                      f'"{namespace}": {exception.reason}'
+            self._logger.error(message)
+            return {
+                'status': exception.status,
+                'message': message
+            }
+
     def get_logs(self, driver_name, namespace):
         try:
             api_response = self._connection.read_namespaced_pod_log(driver_name, namespace)

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -67,15 +67,16 @@ class SparkJobService(ISparkJobService):
                 'message': message
             }
 
-    def get_logs(self, driver_name, namespace):
+    def get_logs(self, job_name, namespace):
         try:
+            driver_name = job_name + "-driver"
             api_response = self._connection.read_namespaced_pod_log(driver_name, namespace)
             return {
                 'message': api_response,
                 'status': StatusCodes.Okay.value
             }
         except ApiException as exception:
-            message = f'Kubernetes error when trying to get logs for driver "{driver_name}" in namespace '\
+            message = f'Kubernetes error when trying to get logs for spark job "{job_name}" in namespace '\
                 f'"{namespace}": {exception.reason}'
             self._logger.error(message)
             return {

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -59,7 +59,7 @@ class SparkJobService(ISparkJobService):
                 'status': StatusCodes.Okay.value
             }
         except ApiException as exception:
-            message = f'Kubernetes error when trying to get status of job with driver "{job_name}" in ' \
+            message = f'Kubernetes error when trying to get status of job "{job_name}" in ' \
                       f'namespace "{namespace}": {exception.reason}'
             self._logger.error(message)
             return {

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -44,21 +44,22 @@ class SparkJobService(ISparkJobService):
                 'message': message
             }
 
-    def get_job_status(self, job_driver_name, namespace):
+    def get_job_status(self, job_name, namespace):
         try:
-            api_response = self._connection.get_namespaced_custom_object_status(
+            api_response = self._connection.get_namespaced_custom_object(
                 CRD_GROUP,
                 CRD_VERSION,
                 namespace,
                 CRD_PLURAL,
-                job_driver_name
+                job_name
             )
+            job_status = api_response['status']['applicationState']['state']
             return {
-                'message': api_response,
+                'message': job_status,
                 'status': StatusCodes.Okay.value
             }
         except ApiException as exception:
-            message = f'Kubernetes error when trying to get status of job with driver "{job_driver_name}" in ' \
+            message = f'Kubernetes error when trying to get status of job with driver "{job_name}" in ' \
                       f'namespace "{namespace}": {exception.reason}'
             self._logger.error(message)
             return {

--- a/piezo_web_app/PiezoWebApp/tests/handlers/get_logs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/get_logs_test.py
@@ -21,13 +21,13 @@ class TestGetLogsHandler(BaseHandlerTest):
 
     @gen_test
     def test_get_returns_400_when_namespace_is_missing(self):
-        body = {'driver_name': 'test-driver'}
+        body = {'job_name': 'test-job'}
         yield self.assert_request_returns_400(body)
 
     @gen_test
     def test_get_returns_logs_when_successful(self):
         # Arrange
-        body = {'driver_name': 'test-driver', 'namespace': 'test-namespace'}
+        body = {'job_name': 'test-job', 'namespace': 'test-namespace'}
         self.mock_spark_job_service.get_logs.return_value = {
             "message": "logs",
             "status": 200
@@ -35,10 +35,10 @@ class TestGetLogsHandler(BaseHandlerTest):
         # Act
         response_body, response_code = yield self.send_request(body)
         # Assert
-        self.mock_spark_job_service.get_logs.assert_called_once_with('test-driver', 'test-namespace')
+        self.mock_spark_job_service.get_logs.assert_called_once_with('test-job', 'test-namespace')
         self.mock_logger.debug.assert_has_calls([
-            call('Trying to delete driver "test-driver" in namespace "test-namespace".'),
-            call('Getting logs from driver "test-driver" in namespace "test-namespace" returned result "200".')
+            call('Trying to get logs from spark job "test-job" in namespace "test-namespace".'),
+            call('Getting logs from spark job "test-job" in namespace "test-namespace" returned result "200".')
         ])
         assert response_code == 200
         self.assertDictEqual(response_body, {

--- a/piezo_web_app/PiezoWebApp/tests/handlers/job_status_handler_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/job_status_handler_test.py
@@ -25,13 +25,13 @@ class TestJobStatusHandler(BaseHandlerTest):
 
     @gen_test
     def test_get_returns_400_when_namespace_is_missing(self):
-        body = {'spark_job': 'test-driver'}
+        body = {'job_name': 'test-driver'}
         yield self.assert_request_returns_400(body)
 
     @gen_test
     def test_get_returns_status_when_successful(self):
         # Arrange
-        body = {'spark_job': 'test-job', 'namespace': 'test-namespace'}
+        body = {'job_name': 'test-job', 'namespace': 'test-namespace'}
         self.mock_spark_job_service.get_job_status.return_value = {
             "message": "status",
             "status": 200
@@ -56,7 +56,7 @@ class TestJobStatusHandler(BaseHandlerTest):
     @gen_test
     def test_get_returns_message_and_status_code_when_k8s_error(self):
         # Arrange
-        body = {'spark_job': 'test-job', 'namespace': 'test-namespace'}
+        body = {'job_name': 'test-job', 'namespace': 'test-namespace'}
         self.mock_spark_job_service.get_job_status.return_value = {
             "message": "Kubernetes error",
             "status": 404

--- a/piezo_web_app/PiezoWebApp/tests/handlers/job_status_handler_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/job_status_handler_test.py
@@ -5,7 +5,7 @@ from PiezoWebApp.tests.handlers.base_handler_test import BaseHandlerTest
 from PiezoWebApp.src.handlers.job_status import JobStatusHandler
 
 
-class TestGetLogsHandler(BaseHandlerTest):
+class TestJobStatusHandler(BaseHandlerTest):
     @property
     def handler(self):
         return JobStatusHandler

--- a/piezo_web_app/PiezoWebApp/tests/handlers/job_status_handler_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/job_status_handler_test.py
@@ -1,0 +1,50 @@
+from mock import call
+from tornado.testing import gen_test
+
+from PiezoWebApp.tests.handlers.base_handler_test import BaseHandlerTest
+from PiezoWebApp.src.handlers.job_status import JobStatusHandler
+
+
+class TestGetLogsHandler(BaseHandlerTest):
+    @property
+    def handler(self):
+        return JobStatusHandler
+
+    @property
+    def standard_request_method(self):
+        return 'GET'
+
+    @gen_test
+    def test_get_returns_400_when_job_name_is_missing(self):
+        body = {'namespace': 'test-namespace'}
+        yield self.assert_request_returns_400(body)
+
+    @gen_test
+    def test_get_returns_400_when_namespace_is_missing(self):
+        body = {'spark_job': 'test-driver'}
+        yield self.assert_request_returns_400(body)
+
+    @gen_test
+    def test_get_returns_status_when_successful(self):
+        # Arrange
+        body = {'spark_job': 'test-job', 'namespace': 'test-namespace'}
+        self.mock_spark_job_service.get_job_status.return_value = {
+            "message": "status",
+            "status": 200
+        }
+        # Act
+        response_body, response_code = yield self.send_request(body)
+        # Assert
+        self.mock_spark_job_service.get_job_status.assert_called_once_with('test-job', 'test-namespace')
+        self.mock_logger.debug.assert_has_calls([
+            call('Trying to get status of spark job "test-job" in namespace "test-namespace".'),
+            call('Getting status of spark job "test-job" in namespace "test-namespace" returned '
+                 'result "200".')
+        ])
+        assert response_code == 200
+        self.assertDictEqual(response_body, {
+            'status': 'success',
+            'data': {
+                'message': 'status'
+            }
+        })

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/job_status_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/job_status_test.py
@@ -30,7 +30,7 @@ class TestJobStatusIntegration(BaseIntegrationTest):
     @gen_test
     def test_status_is_returned_from_correct_spark_job(self):
         # Arrange
-        body = {'spark_job': 'test-spark-job', 'namespace': 'default'}
+        body = {'job_name': 'test-spark-job', 'namespace': 'default'}
         kubernetes_response = {'status': {'applicationState': {'state': 'Running'}}}
         self.mock_k8s_adapter.get_namespaced_custom_object.return_value = kubernetes_response
         # Act
@@ -53,7 +53,7 @@ class TestJobStatusIntegration(BaseIntegrationTest):
     @gen_test
     def test_trying_to_get_status_of_non_existent_job_returns_404_with_reason(self):
         # Arrange
-        body = {'spark_job': 'test-spark-job', 'namespace': 'default'}
+        body = {'job_name': 'test-spark-job', 'namespace': 'default'}
         self.mock_k8s_adapter.get_namespaced_custom_object.side_effect = ApiException(status=404, reason="Not Found")
         # Act
         with pytest.raises(HTTPClientError) as exception:

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/job_status_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/job_status_test.py
@@ -1,0 +1,65 @@
+import json
+import pytest
+from tornado.httpclient import HTTPClientError
+from tornado.testing import gen_test
+from kubernetes.client.rest import ApiException
+
+from PiezoWebApp.src.handlers.job_status import JobStatusHandler
+from PiezoWebApp.tests.integration_tests.base_integration_test import BaseIntegrationTest
+
+
+# str | The custom resource's group name
+CRD_GROUP = 'sparkoperator.k8s.io'
+
+# str | The custom resource's plural name. For TPRs this would be lowercase plural kind.
+CRD_PLURAL = 'sparkapplications'
+
+# str | The custom resource's version
+CRD_VERSION = 'v1beta1'
+
+
+class TestJobStatusIntegration(BaseIntegrationTest):
+    @property
+    def handler(self):
+        return JobStatusHandler
+
+    @property
+    def standard_request_method(self):
+        return 'GET'
+
+    @gen_test
+    def test_status_is_returned_from_correct_spark_job(self):
+        # Arrange
+        body = {'spark_job': 'test-spark-job', 'namespace': 'default'}
+        kubernetes_response = {'status': {'applicationState': {'state': 'Running'}}}
+        self.mock_k8s_adapter.get_namespaced_custom_object.return_value = kubernetes_response
+        # Act
+        response_body, response_code = yield self.send_request(body)
+        # Assert
+        assert self.mock_k8s_adapter.get_namespaced_custom_object.call_count == 1
+        call_args = self.mock_k8s_adapter.get_namespaced_custom_object.call_args[0]
+        assert call_args[0] == CRD_GROUP
+        assert call_args[1] == CRD_VERSION
+        assert call_args[2] == 'default'
+        assert call_args[3] == CRD_PLURAL
+        assert call_args[4] == 'test-spark-job'
+        assert response_code == 200
+        self.assertDictEqual(response_body, {
+            'status': 'success',
+            'data': {
+                'message': 'Running'
+            }
+        })
+
+    @gen_test
+    def test_trying_to_get_status_of_non_existent_job_returns_404_with_reason(self):
+        # Arrange
+        body = {'spark_job': 'test-spark-job', 'namespace': 'default'}
+        self.mock_k8s_adapter.get_namespaced_custom_object.side_effect = ApiException(status=404, reason="Not Found")
+        # Act
+        with pytest.raises(HTTPClientError) as exception:
+            yield self.send_request(body)
+        assert exception.value.response.code == 404
+        msg = json.loads(exception.value.response.body, encoding='utf-8')['data']
+        assert msg == 'Kubernetes error when trying to get status of spark job "test-spark-job" in' \
+                      ' namespace "default": Not Found'

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/job_status_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/job_status_test.py
@@ -37,12 +37,11 @@ class TestJobStatusIntegration(BaseIntegrationTest):
         response_body, response_code = yield self.send_request(body)
         # Assert
         assert self.mock_k8s_adapter.get_namespaced_custom_object.call_count == 1
-        call_args = self.mock_k8s_adapter.get_namespaced_custom_object.call_args[0]
-        assert call_args[0] == CRD_GROUP
-        assert call_args[1] == CRD_VERSION
-        assert call_args[2] == 'default'
-        assert call_args[3] == CRD_PLURAL
-        assert call_args[4] == 'test-spark-job'
+        self.mock_k8s_adapter.get_namespaced_custom_object.assert_called_once_with(CRD_GROUP,
+                                                                                   CRD_VERSION,
+                                                                                   'default',
+                                                                                   CRD_PLURAL,
+                                                                                   'test-spark-job')
         assert response_code == 200
         self.assertDictEqual(response_body, {
             'status': 'success',

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -203,9 +203,10 @@ class TestSparkJobService(TestCase):
 
     def test_get_job_status_sends_expected_arguments(self):
         # Arrange
-        self.mock_kubernetes_adapter.get_namespaced_custom_object.return_value = {'status':
-                                                                                       {'applicationState':
-                                                                                            {'state': 'Running'}}}
+        self.mock_kubernetes_adapter.get_namespaced_custom_object.return_value = {
+            'status': {
+                'applicationState': {
+                    'state': 'Running'}}}
         # Act
         result = self.test_service.get_job_status('test-job', 'test-namespace')
         # Assert

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -226,11 +226,11 @@ class TestSparkJobService(TestCase):
         result = self.test_service.get_job_status('test-job', 'test-namespace')
         # Assert
         expected_message = \
-            'Kubernetes error when trying to get status of job "test-job" in ' \
+            'Kubernetes error when trying to get status of spark job "test-job" in ' \
             'namespace "test-namespace": Reason'
         self.mock_logger.error.assert_called_once_with(expected_message)
         self.assertDictEqual(result, {
             'status': 999,
-            'message': 'Kubernetes error when trying to get status of job "test-job" in namespace'
+            'message': 'Kubernetes error when trying to get status of spark job "test-job" in namespace'
                        ' "test-namespace": Reason'
         })

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -76,23 +76,24 @@ class TestSparkJobService(TestCase):
         # Arrange
         self.mock_kubernetes_adapter.read_namespaced_pod_log.return_value = "Response"
         # Act
-        result = self.test_service.get_logs('test-driver', 'test-namespace')
+        result = self.test_service.get_logs('test-job', 'test-namespace')
         # Assert
         self.assertDictEqual(result, {'message': 'Response', 'status': 200})
-        self.mock_kubernetes_adapter.read_namespaced_pod_log.assert_called_once_with('test-driver', 'test-namespace')
+        self.mock_kubernetes_adapter.read_namespaced_pod_log.assert_called_once_with(
+            'test-job-driver', 'test-namespace')
 
     def test_get_logs_logs_and_returns_api_exception_reason(self):
         # Arrange
         self.mock_kubernetes_adapter.read_namespaced_pod_log.side_effect = ApiException(reason="Reason", status=999)
         # Act
-        result = self.test_service.get_logs('test-driver', 'test-namespace')
+        result = self.test_service.get_logs('test-job', 'test-namespace')
         # Assert
         expected_message = \
-            'Kubernetes error when trying to get logs for driver "test-driver" in namespace "test-namespace": Reason'
+            'Kubernetes error when trying to get logs for spark job "test-job" in namespace "test-namespace": Reason'
         self.mock_logger.error.assert_called_once_with(expected_message)
         self.assertDictEqual(result, {
             'status': 999,
-            'message': 'Kubernetes error when trying to get logs for driver "test-driver" '
+            'message': 'Kubernetes error when trying to get logs for spark job "test-job" '
                        'in namespace "test-namespace": Reason'
         })
 


### PR DESCRIPTION
New `jobstatus` handler to get the status of a spark application running through Piezo web app. Takes arguments of `spark_job` and `namespace`. If the job is present then it returns a 200 with body {"status": "success", "data": {"message": "Status"}} Where `Status` can be Running, Completed or Failed. When not present Piezo web app will return a 404 with a message saying `Kubernetes error when trying to get status of spark job "X" in namespace "Y": Not Found' Due to an error with the kubernetes API can't use the python client to call status of job directly. Instead rely on getting the job and extracting the status from the body.

## Stories covered:
#46 

## To test:
Run unit tests,
Run integration tests