### PR TITLE
Bug fix/fix delete job handler/#58

### DIFF
--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -74,5 +74,5 @@ Wait For Spark Job To Finish
     \   ${response}=   Get Status Of Spark Job   ${job_name}
     \   ${message}=  Get Response Data Message     ${response}
     \   ${finished}=    Set Variable If     '${message}'=='COMPLETED'   ${True}     ${False}
-    \   Exit For Loop If    ${finished}==${True}
+    \   Exit For Loop If    ${finished}
     [return]    ${finished}

--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -66,3 +66,13 @@ Submit SparkPi Job
     ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.SparkPi    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
     [return]  ${response}
+
+Wait For Spark Job To Finish
+    [Arguments]    ${job_name}
+    :For    ${i}    IN RANGE   0    24    
+    \   Sleep     5 seconds
+    \   ${response}=   Get Status Of Spark Job   ${job_name}
+    \   ${message}=  Get Response Data Message     ${response}
+    \   ${finished}=    Set Variable If     '${message}'=='COMPLETED'   ${True}     ${False}
+    \   Exit For Loop If    ${finished}==${True}
+    [return]    ${finished}

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -46,7 +46,8 @@ Submit Spark Pi Job Returns Ok Response
 Can Get Logs Of Submitted Spark Job
     ${job_name}=     Set Variable   spark-pi-fe244
     Submit SparkPi Job    ${job_name}
-    Sleep   1 minute
+    ${finished}=    Wait For Spark Job To Finish        ${job_name}
+    Should Be True      ${finished}
     ${response}=  Get Logs For Spark Job    ${job_name}
     ${joblog}=    Get Response Data Message   ${response}
     ${pi_lines}=    Get Lines Containing String   ${joblog}   Pi is roughly 3
@@ -56,15 +57,14 @@ Can Get Logs Of Submitted Spark Job
 Can Delete Submitted Spark Job
     ${job_name}=    Set Variable        spark-pi-83783
     Submit SparkPi Job   ${job_name}
-    Sleep   1 minute
+    ${finished}=    Wait For Spark Job To Finish        ${job_name}
+    Should Be True    ${finished} 
     ${response}=  Delete Spark Job    ${job_name}
     Confirm Ok Response   ${response}
 
 Can Get Status Of Submitted Spark Job
     ${job_name}=     Set Variable       spark-pi-5jk23s
     Submit SparkPi Job    ${job_name}
-    Sleep   1 minute
+    Sleep       5 seconds
     ${response}=  Get Status Of Spark Job   ${job_name}
     Confirm Ok Response     ${response}
-    ${data}=  Get Response Data     ${response}
-    Should Be Equal As Strings       ${data["message"]}        COMPLETED

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
@@ -8,6 +8,16 @@ class IKubernetesAdapter(metaclass=ABCMeta):
     def delete_namespaced_custom_object(self, group, version, namespace, plural, name, body):
         pass
 
+    # pylint: disable=too-many-arguments
+    @staticmethod
+    def delete_options(api_version=None,
+                       dry_run=None,
+                       grace_period_seconds=None,
+                       kind=None, orphan_dependents=None,
+                       pre_conditions=None,
+                       propagation_policy=None):
+        pass
+
     @abstractmethod
     def read_namespaced_pod_log(self, driver_name, namespace):
         pass

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
@@ -9,8 +9,9 @@ class IKubernetesAdapter(metaclass=ABCMeta):
         pass
 
     # pylint: disable=too-many-arguments
-    @staticmethod
-    def delete_options(api_version=None,
+    @abstractmethod
+    def delete_options(self,
+                       api_version=None,
                        dry_run=None,
                        grace_period_seconds=None,
                        kind=None, orphan_dependents=None,

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
@@ -14,7 +14,8 @@ class IKubernetesAdapter(metaclass=ABCMeta):
                        api_version=None,
                        dry_run=None,
                        grace_period_seconds=None,
-                       kind=None, orphan_dependents=None,
+                       kind=None,
+                       orphan_dependents=None,
                        pre_conditions=None,
                        propagation_policy=None):
         pass

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
@@ -9,10 +9,6 @@ class IKubernetesAdapter(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def delete_options(self, **kwargs):
-        pass
-
-    @abstractmethod
     def read_namespaced_pod_log(self, driver_name, namespace):
         pass
 

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
@@ -14,8 +14,8 @@ class KubernetesAdapter(IKubernetesAdapter):
         return self._custom_connection.delete_namespaced_custom_object(group, version, namespace, plural, name, body)
 
     # pylint: disable=too-many-arguments
-    @staticmethod
-    def delete_options(api_version=None,
+    def delete_options(self,
+                       api_version=None,
                        dry_run=None,
                        grace_period_seconds=None,
                        kind=None, orphan_dependents=None,

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
@@ -13,6 +13,22 @@ class KubernetesAdapter(IKubernetesAdapter):
     def delete_namespaced_custom_object(self, group, version, namespace, plural, name, body):
         return self._custom_connection.delete_namespaced_custom_object(group, version, namespace, plural, name, body)
 
+    # pylint: disable=too-many-arguments
+    @staticmethod
+    def delete_options(api_version=None,
+                       dry_run=None,
+                       grace_period_seconds=None,
+                       kind=None, orphan_dependents=None,
+                       pre_conditions=None,
+                       propagation_policy=None):
+        return {'api_version': api_version,
+                'dry_run': dry_run,
+                'grace_period_seconds': grace_period_seconds,
+                'kind': kind,
+                'orphan_dependents': orphan_dependents,
+                'preconditions': pre_conditions,
+                'propagation_policy': propagation_policy}
+
     def read_namespaced_pod_log(self, driver_name, namespace):
         return self._core_connection.read_namespaced_pod_log(driver_name, namespace)
 

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
@@ -13,9 +13,6 @@ class KubernetesAdapter(IKubernetesAdapter):
     def delete_namespaced_custom_object(self, group, version, namespace, plural, name, body):
         return self._custom_connection.delete_namespaced_custom_object(group, version, namespace, plural, name, body)
 
-    def delete_options(self, **kwargs):
-        return kubernetes.client.V1DeleteOptions(kwargs)
-
     def read_namespaced_pod_log(self, driver_name, namespace):
         return self._core_connection.read_namespaced_pod_log(driver_name, namespace)
 

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
@@ -18,7 +18,8 @@ class KubernetesAdapter(IKubernetesAdapter):
                        api_version=None,
                        dry_run=None,
                        grace_period_seconds=None,
-                       kind=None, orphan_dependents=None,
+                       kind=None,
+                       orphan_dependents=None,
                        pre_conditions=None,
                        propagation_policy=None):
         return {'api_version': api_version,

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -37,8 +37,11 @@ class SparkJobService(ISparkJobService):
                 job_name,
                 body
             )
+
+            msg = f"{job_name} deleted from namespace {namespace}" if api_response['status'] == "Success"\
+                else f"Trying to delete job {job_name} resulted in status: {api_response['status']}"
             return {
-                'message': f"Deleting job {job_name} completed with status {api_response['status']}",
+                'message': msg,
                 'status': StatusCodes.Okay.value
             }
         except ApiException as exception:

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -22,7 +22,13 @@ class SparkJobService(ISparkJobService):
 
     def delete_job(self, job_name, namespace):
         try:
-            body = self._connection.delete_options()
+            body = {'api_version': None,
+                    'dry_run': None,
+                    'grace_period_seconds': None,
+                    'kind': None,
+                    'orphan_dependents': None,
+                    'preconditions': None,
+                    'propagation_policy': None}
             api_response = self._connection.delete_namespaced_custom_object(
                 CRD_GROUP,
                 CRD_VERSION,
@@ -32,7 +38,7 @@ class SparkJobService(ISparkJobService):
                 body
             )
             return {
-                'message': api_response.content,
+                'message': f"Job {job_name} deleted successfully",
                 'status': StatusCodes.Okay.value
             }
         except ApiException as exception:

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -22,13 +22,7 @@ class SparkJobService(ISparkJobService):
 
     def delete_job(self, job_name, namespace):
         try:
-            body = {'api_version': None,
-                    'dry_run': None,
-                    'grace_period_seconds': None,
-                    'kind': None,
-                    'orphan_dependents': None,
-                    'preconditions': None,
-                    'propagation_policy': None}
+            body = self._connection.delete_options()
             api_response = self._connection.delete_namespaced_custom_object(
                 CRD_GROUP,
                 CRD_VERSION,

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -38,7 +38,7 @@ class SparkJobService(ISparkJobService):
                 body
             )
             return {
-                'message': f"Job {job_name} deleted successfully",
+                'message': f"Deleting job {job_name} completed with status {api_response['status']}",
                 'status': StatusCodes.Okay.value
             }
         except ApiException as exception:

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/delete_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/delete_job_test.py
@@ -32,7 +32,7 @@ class DeleteJobIntegrationTest(BaseIntegrationTest):
         body = {"job_name": "test-spark-job", "namespace": "default"}
         kubernetes_response = {'status': 'Success'}
         self.mock_k8s_adapter.delete_namespaced_custom_object.return_value = kubernetes_response
-        self.mock_k8s_adapter.delete_options.return_value = "Options"
+        self.mock_k8s_adapter.delete_options.return_value = {"api_version": "version", "other_values": "values"}
         # Act
         response_body, response_code = yield self.send_request(body)
         # Assert
@@ -42,7 +42,10 @@ class DeleteJobIntegrationTest(BaseIntegrationTest):
                                                                                       'default',
                                                                                       CRD_PLURAL,
                                                                                       'test-spark-job',
-                                                                                      "Options")
+                                                                                      {
+                                                                                          "api_version": "version",
+                                                                                          "other_values": "values"
+                                                                                      })
         assert response_code == 200
         self.assertDictEqual(response_body, {
             'status': 'success',

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/delete_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/delete_job_test.py
@@ -16,14 +16,6 @@ CRD_PLURAL = 'sparkapplications'
 # str | The custom resource's version
 CRD_VERSION = 'v1beta1'
 
-DELETE_OPTIONS = {'api_version': None,
-                  'dry_run': None,
-                  'grace_period_seconds': None,
-                  'kind': None,
-                  'orphan_dependents': None,
-                  'preconditions': None,
-                  'propagation_policy': None}
-
 
 class DeleteJobIntegrationTest(BaseIntegrationTest):
     @property
@@ -40,6 +32,7 @@ class DeleteJobIntegrationTest(BaseIntegrationTest):
         body = {"job_name": "test-spark-job", "namespace": "default"}
         kubernetes_response = {'status': 'Success'}
         self.mock_k8s_adapter.delete_namespaced_custom_object.return_value = kubernetes_response
+        self.mock_k8s_adapter.delete_options.return_value = "Options"
         # Act
         response_body, response_code = yield self.send_request(body)
         # Assert
@@ -49,7 +42,7 @@ class DeleteJobIntegrationTest(BaseIntegrationTest):
                                                                                       'default',
                                                                                       CRD_PLURAL,
                                                                                       'test-spark-job',
-                                                                                      DELETE_OPTIONS)
+                                                                                      "Options")
         assert response_code == 200
         self.assertDictEqual(response_body, {
             'status': 'success',

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/delete_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/delete_job_test.py
@@ -1,10 +1,72 @@
+import json
+import pytest
+from tornado.httpclient import HTTPClientError
+from tornado.testing import gen_test
+from kubernetes.client.rest import ApiException
+
 from PiezoWebApp.src.handlers.delete_job import DeleteJobHandler
 from PiezoWebApp.tests.integration_tests.base_integration_test import BaseIntegrationTest
 
+# str | The custom resource's group name
+CRD_GROUP = 'sparkoperator.k8s.io'
+
+# str | The custom resource's plural name. For TPRs this would be lowercase plural kind.
+CRD_PLURAL = 'sparkapplications'
+
+# str | The custom resource's version
+CRD_VERSION = 'v1beta1'
+
+DELETE_OPTIONS = {'api_version': None,
+                  'dry_run': None,
+                  'grace_period_seconds': None,
+                  'kind': None,
+                  'orphan_dependents': None,
+                  'preconditions': None,
+                  'propagation_policy': None}
+
 
 class DeleteJobIntegrationTest(BaseIntegrationTest):
+    @property
     def handler(self):
         return DeleteJobHandler
 
+    @property
     def standard_request_method(self):
-        return "DELETE"
+        return 'DELETE'
+
+    @gen_test
+    def test_success_message_is_returned_when_job_deleted_successfully(self):
+        # Arrange
+        body = {"job_name": "test-spark-job", "namespace": "default"}
+        kubernetes_response = {'status': 'Success'}
+        self.mock_k8s_adapter.delete_namespaced_custom_object.return_value = kubernetes_response
+        # Act
+        response_body, response_code = yield self.send_request(body)
+        # Assert
+        assert self.mock_k8s_adapter.delete_namespaced_custom_object.call_count == 1
+        self.mock_k8s_adapter.delete_namespaced_custom_object.assert_called_once_with(CRD_GROUP,
+                                                                                      CRD_VERSION,
+                                                                                      'default',
+                                                                                      CRD_PLURAL,
+                                                                                      'test-spark-job',
+                                                                                      DELETE_OPTIONS)
+        assert response_code == 200
+        self.assertDictEqual(response_body, {
+            'status': 'success',
+            'data': {
+                'message': 'test-spark-job deleted from namespace default'
+            }
+        })
+
+    @gen_test
+    def test_trying_to_delete_non_existent_job_returns_404_with_reason(self):
+        # Arrange
+        body = {'job_name': 'test-spark-job', 'namespace': 'default'}
+        self.mock_k8s_adapter.delete_namespaced_custom_object.side_effect = ApiException(status=404, reason="Not Found")
+        # Act
+        with pytest.raises(HTTPClientError) as exception:
+            yield self.send_request(body)
+        assert exception.value.response.code == 404
+        msg = json.loads(exception.value.response.body, encoding='utf-8')['data']
+        assert msg == 'Kubernetes error when trying to delete job "test-spark-job" in' \
+                      ' namespace "default": Not Found'

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -40,6 +40,7 @@ class TestSparkJobService(TestCase):
     def test_delete_job_sends_expected_arguments(self):
         # Arrange
         k8s_response = {'status': 'Success'}
+        self.mock_kubernetes_adapter.delete_options.return_value = "Options"
         self.mock_kubernetes_adapter.delete_namespaced_custom_object.return_value = k8s_response
         # Act
         result = self.test_service.delete_job('test-spark-job', 'test-namespace')
@@ -51,13 +52,7 @@ class TestSparkJobService(TestCase):
             'test-namespace',
             CRD_PLURAL,
             'test-spark-job',
-            {'api_version': None,
-             'dry_run': None,
-             'grace_period_seconds': None,
-             'kind': None,
-             'orphan_dependents': None,
-             'preconditions': None,
-             'propagation_policy': None}
+            "Options"
         )
 
     def test_delete_job_logs_and_returns_api_exception_reason(self):

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -40,7 +40,7 @@ class TestSparkJobService(TestCase):
     def test_delete_job_sends_expected_arguments(self):
         # Arrange
         k8s_response = {'status': 'Success'}
-        self.mock_kubernetes_adapter.delete_options.return_value = "Options"
+        self.mock_kubernetes_adapter.delete_options.return_value = {"api_version": "version", "other_values": "values"}
         self.mock_kubernetes_adapter.delete_namespaced_custom_object.return_value = k8s_response
         # Act
         result = self.test_service.delete_job('test-spark-job', 'test-namespace')
@@ -52,7 +52,7 @@ class TestSparkJobService(TestCase):
             'test-namespace',
             CRD_PLURAL,
             'test-spark-job',
-            "Options"
+            {"api_version": "version", "other_values": "values"}
         )
 
     def test_delete_job_logs_and_returns_api_exception_reason(self):

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -40,13 +40,12 @@ class TestSparkJobService(TestCase):
 
     def test_delete_job_sends_expected_arguments(self):
         # Arrange
-        k8s_response = SimpleNamespace()
-        k8s_response.content = "Response"
+        k8s_response = {'status': 'Success'}
         self.mock_kubernetes_adapter.delete_namespaced_custom_object.return_value = k8s_response
         # Act
         result = self.test_service.delete_job('test-spark-job', 'test-namespace')
         # Assert
-        self.assertDictEqual(result, {'message': 'Response', 'status': 200})
+        self.assertDictEqual(result, {'message': 'test-spark-job deleted from namespace test-namespace', 'status': 200})
         self.mock_kubernetes_adapter.delete_namespaced_custom_object.assert_called_once_with(
             CRD_GROUP,
             CRD_VERSION,

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -1,5 +1,4 @@
 from logging import Logger
-from types import SimpleNamespace
 from unittest import TestCase
 
 from kubernetes.client.rest import ApiException

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -42,7 +42,6 @@ class TestSparkJobService(TestCase):
         # Arrange
         k8s_response = SimpleNamespace()
         k8s_response.content = "Response"
-        self.mock_kubernetes_adapter.delete_options.return_value = {'test-option': None}
         self.mock_kubernetes_adapter.delete_namespaced_custom_object.return_value = k8s_response
         # Act
         result = self.test_service.delete_job('test-spark-job', 'test-namespace')
@@ -54,7 +53,13 @@ class TestSparkJobService(TestCase):
             'test-namespace',
             CRD_PLURAL,
             'test-spark-job',
-            {'test-option': None}
+            {'api_version': None,
+             'dry_run': None,
+             'grace_period_seconds': None,
+             'kind': None,
+             'orphan_dependents': None,
+             'preconditions': None,
+             'propagation_policy': None}
         )
 
     def test_delete_job_logs_and_returns_api_exception_reason(self):


### PR DESCRIPTION
Fix the delet job handler so that it now successfully deletes jobs. Note V1 delete options are now hard coded in due to bug in the python client. However these can still be set if we ever allow optional inputs for these. 
#58 

## To test:
* Run system tests (all should now pass)
* run integration and unit tests