### PR TITLE
Feature/add optional label input/#52

### DIFF
--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -63,19 +63,20 @@ Post Request With Json Body
 
 Submit SparkPi Job
     [Arguments]   ${job_name}
-    ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.SparkPi    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar 
+    ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.SparkPi    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
     [return]  ${response}
 
 Submit SparkGroupByTest Job With Arguments
     [Arguments]   ${job_name}
-    ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.GroupByTest    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar      arguments=["10", "670", "1300", "3"]
+    ${arguments}=   Create List   10  670  1300   3
+    ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.GroupByTest    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar      arguments=${arguments}
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
     [return]  ${response}
 
 Wait For Spark Job To Finish
     [Arguments]    ${job_name}
-    :For    ${i}    IN RANGE   0    24    
+    :For    ${i}    IN RANGE   0    24
     \   Sleep     5 seconds
     \   ${response}=   Get Status Of Spark Job   ${job_name}
     \   ${message}=  Get Response Data Message     ${response}

--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -63,7 +63,7 @@ Post Request With Json Body
 
 Submit SparkPi Job
     [Arguments]   ${job_name}
-    ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.SparkPi    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar
+    ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.SparkPi    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar      arguments=["10"]
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
     [return]  ${response}
 

--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -63,7 +63,13 @@ Post Request With Json Body
 
 Submit SparkPi Job
     [Arguments]   ${job_name}
-    ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.SparkPi    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar      arguments=["10"]
+    ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.SparkPi    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar 
+    ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
+    [return]  ${response}
+
+Submit SparkGroupByTest Job With Arguments
+    [Arguments]   ${job_name}
+    ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.GroupByTest    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar      arguments=["10", "670", "1300", "3"]
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
     [return]  ${response}
 

--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -53,7 +53,6 @@ Get Status Of Spark Job
     ${response}=  Get Request With Json Body   /piezo/jobstatus    ${body}
     [return]    ${response}
 
-
 Post Request With Json Body
     [Arguments]   ${route}    ${body}
     ${headers}=   Json Header
@@ -63,14 +62,14 @@ Post Request With Json Body
 
 Submit SparkPi Job
     [Arguments]   ${job_name}
-    ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.SparkPi    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar
+    ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.SparkPi    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar    label=systemTest
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
     [return]  ${response}
 
 Submit SparkGroupByTest Job With Arguments
     [Arguments]   ${job_name}
     ${arguments}=   Create List   10  670  1300   3
-    ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.GroupByTest    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar      arguments=${arguments}
+    ${submitbody}=    Create Dictionary   name=${job_name}   language=Scala   main_class=org.apache.spark.examples.GroupByTest    path_to_main_app_file=local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar      label=systemTest      arguments=${arguments}
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
     [return]  ${response}
 

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -44,7 +44,7 @@ Submit Spark Pi Job Returns Ok Response
     Should Be Equal As Strings    ${data["driver_name"]}   spark-pi-3f69c-driver
 
 Submit GroupByTest Spark Job With Arguments Returns Ok Response
-    ${response}=    Submit SparkGroupByTest Job    spark-group-by-test-8s2xp
+    ${response}=    Submit SparkGroupByTest Job With Arguments   spark-group-by-test-8s2xp
     Confirm Ok Response  ${response}
     ${data}=    Get Response Data   ${response}
     Should Be Equal As Strings    ${data["message"]}    Job driver created successfully
@@ -61,11 +61,26 @@ Can Get Logs Of Submitted Spark Job
     ${num_pi_lines}=    Get Line Count    ${pi_lines}
     Should Be Equal As Integers   ${num_pi_lines}   1
 
+Arguments Have Been Read And Appear In Logs
+    ${job_name}=  Set Variable  spark-group-by-test-3ewc7
+    ${response}=    Submit SparkGroupByTest Job With Arguments   ${job_name}
+    Confirm Ok Response  ${response}
+    ${finished}=    Wait For Spark Job To Finish        ${job_name}
+    Should Be True      ${finished}
+    ${logresponse}=  Get Logs For Spark Job    ${job_name}
+    ${joblog}=  Get Response Data Message   ${logresponse}
+    ${arg_1_lines}=    Get Lines Containing String   ${joblog}   Adding task set 0.0 with 10 tasks
+    ${arg_4_lines}=    Get Lines Containing String   ${joblog}   Adding task set 2.0 with 3 tasks
+    ${num_arg_1_lines}=    Get Line Count    ${arg_1_lines}
+    ${num_arg_4_lines}=    Get Line Count    ${arg_4_lines}
+    Should Be Equal As Integers   ${num_arg_1_lines}   1
+    Should Be Equal As Integers   ${num_arg_4_lines}   1
+
 Can Delete Submitted Spark Job
     ${job_name}=    Set Variable        spark-pi-83783
     Submit SparkPi Job   ${job_name}
     ${finished}=    Wait For Spark Job To Finish        ${job_name}
-    Should Be True    ${finished} 
+    Should Be True    ${finished}
     ${response}=  Delete Spark Job    ${job_name}
     Confirm Ok Response   ${response}
 

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -43,6 +43,13 @@ Submit Spark Pi Job Returns Ok Response
     Should Be Equal As Strings    ${data["message"]}    Job driver created successfully
     Should Be Equal As Strings    ${data["driver_name"]}   spark-pi-3f69c-driver
 
+Submit GroupByTest Spark Job With Arguments Returns Ok Response
+    ${response}=    Submit SparkGroupByTest Job    spark-group-by-test-8s2xp
+    Confirm Ok Response  ${response}
+    ${data}=    Get Response Data   ${response}
+    Should Be Equal As Strings    ${data["message"]}    Job driver created successfully
+    Should Be Equal As Strings    ${data["driver_name"]}   spark-group-by-test-8s2xp-driver
+
 Can Get Logs Of Submitted Spark Job
     ${job_name}=     Set Variable   spark-pi-fe244
     Submit SparkPi Job    ${job_name}

--- a/piezo_web_app/PiezoWebApp/example_validation_rules.json
+++ b/piezo_web_app/PiezoWebApp/example_validation_rules.json
@@ -109,5 +109,9 @@
     "default": "512m",
     "minimum": 512,
     "maximum": 4096
+  },
+  {
+    "input_name": "label",
+    "classification": "Optional"
   }
 ]

--- a/piezo_web_app/PiezoWebApp/example_validation_rules.json
+++ b/piezo_web_app/PiezoWebApp/example_validation_rules.json
@@ -1,7 +1,8 @@
 [
   {
     "input_name": "arguments",
-    "classification": "Optional"
+    "classification": "Optional",
+    "type": "array"
   },
   {
     "input_name": "apiVersion",

--- a/piezo_web_app/PiezoWebApp/example_validation_rules.json
+++ b/piezo_web_app/PiezoWebApp/example_validation_rules.json
@@ -1,10 +1,5 @@
 [
   {
-    "input_name": "arguments",
-    "classification": "Optional",
-    "type": "array"
-  },
-  {
     "input_name": "apiVersion",
     "classification": "Fixed",
     "default": "sparkoperator.k8s.io/v1beta1"
@@ -74,6 +69,11 @@
     "classification": "Conditional",
     "conditional_input_name": "language",
     "conditional_input_value": "Scala"
+  },
+  {
+    "input_name": "arguments",
+    "classification": "Optional",
+    "type": "array"
   },
   {
     "input_name": "driver_cores",

--- a/piezo_web_app/PiezoWebApp/example_validation_rules.json
+++ b/piezo_web_app/PiezoWebApp/example_validation_rules.json
@@ -1,5 +1,9 @@
 [
   {
+    "input_name": "arguments",
+    "classification": "Optional"
+  },
+  {
     "input_name": "apiVersion",
     "classification": "Fixed",
     "default": "sparkoperator.k8s.io/v1beta1"

--- a/piezo_web_app/PiezoWebApp/src/models/validation_rule.py
+++ b/piezo_web_app/PiezoWebApp/src/models/validation_rule.py
@@ -15,19 +15,13 @@ class ValidationRule:
         self._maximum = self._safe_get_value('maximum', rule_dict)
         self._options = self._safe_get_value('options', rule_dict)
 
-        self._type = self._safe_get_type('type', rule_dict)
+        self._type = self._safe_get_value('type', rule_dict, value_if_missing="string")
 
     @staticmethod
-    def _safe_get_value(key, dictionary):
+    def _safe_get_value(key, dictionary, value_if_missing=None):
         if key in dictionary:
             return dictionary[key]
-        return None
-
-    @staticmethod
-    def _safe_get_type(key, dictionary):
-        if key in dictionary:
-            return dictionary[key]
-        return "string"
+        return value_if_missing
 
     @property
     def classification(self):

--- a/piezo_web_app/PiezoWebApp/src/models/validation_rule.py
+++ b/piezo_web_app/PiezoWebApp/src/models/validation_rule.py
@@ -56,3 +56,7 @@ class ValidationRule:
     @property
     def options(self):
         return self._options
+
+    @property
+    def type(self):
+        return self._type

--- a/piezo_web_app/PiezoWebApp/src/models/validation_rule.py
+++ b/piezo_web_app/PiezoWebApp/src/models/validation_rule.py
@@ -15,11 +15,19 @@ class ValidationRule:
         self._maximum = self._safe_get_value('maximum', rule_dict)
         self._options = self._safe_get_value('options', rule_dict)
 
+        self._type = self._safe_get_type('type', rule_dict)
+
     @staticmethod
     def _safe_get_value(key, dictionary):
         if key in dictionary:
             return dictionary[key]
         return None
+
+    @staticmethod
+    def _safe_get_type(key, dictionary):
+        if key in dictionary:
+            return dictionary[key]
+        return "string"
 
     @property
     def classification(self):

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
@@ -3,7 +3,7 @@ from PiezoWebApp.src.models.spark_job_validation_result import ValidationResult
 
 
 def validate(key, value, validation_rule):
-    if key in ["name", "path_to_main_app_file", "main_class"]:
+    if key in ["name", "path_to_main_app_file", "main_class", "label"]:
         return _validate_non_empty_string(key, value)
     if key in ["language", "python_version"]:
         return _validate_string_from_list(key, value, validation_rule)

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
@@ -13,6 +13,8 @@ def validate(key, value, validation_rule):
         return _validate_multiple_of_a_tenth(key, value, validation_rule)
     if key in ["driver_memory", "executor_memory"]:
         return _validate_byte_quantity(key, value, validation_rule)
+    if key in ["arguments"]:
+        return ValidationResult(True, None, value)
     raise ValueError(f"Unexpected argument {key}")
 
 

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
@@ -22,13 +22,11 @@ class ManifestPopulator(IManifestPopulator):
         self._spec_restart_policy_type = self._validation_rules.get_default_value_for_key("restart_policy")
         self._spec_driver_cores = self._validation_rules.get_default_value_for_key("driver_cores")
         self._spec_driver_memory = self._validation_rules.get_default_value_for_key("driver_memory")
-        self._spec_driver_label_custom = self._validation_rules.get_default_value_for_key("label")
         self._spec_driver_label_version = self._validation_rules.get_default_value_for_key("spark_version")
         self._spec_driver_service_account = self._validation_rules.get_default_value_for_key("service_account")
         self._spec_executor_instances = self._validation_rules.get_default_value_for_key("executors")
         self._spec_executor_cores = self._validation_rules.get_default_value_for_key("executor_cores")
         self._spec_executor_memory = self._validation_rules.get_default_value_for_key("executor_memory")
-        self._spec_executor_label_custom = self._validation_rules.get_default_value_for_key("label")
         self._spec_executor_label_version = self._validation_rules.get_default_value_for_key("spark_version")
         self._s3_endpoint = configuration.s3_endpoint
         self._secret_name = configuration.s3_secrets_name
@@ -65,8 +63,7 @@ class ManifestPopulator(IManifestPopulator):
                         "cores": self._spec_driver_cores,
                         "memory": self._spec_driver_memory,
                         "labels": {
-                            "version": self._spec_driver_label_version,
-                            "tag": self._spec_driver_label_custom},
+                            "version": self._spec_driver_label_version},
                         "serviceAccount": self._spec_driver_service_account,
                         "envSecretKeyRefs": {
                             "AWS_ACCESS_KEY_ID": {
@@ -80,8 +77,7 @@ class ManifestPopulator(IManifestPopulator):
                         "instances": self._spec_executor_instances,
                         "memory": self._spec_executor_memory,
                         "labels": {
-                            "version": self._spec_executor_label_version,
-                            "tag": self._spec_executor_label_custom},
+                            "version": self._spec_executor_label_version},
                         "envSecretKeyRefs": {
                             "AWS_ACCESS_KEY_ID": {
                                 "name": self._secret_name,
@@ -93,7 +89,7 @@ class ManifestPopulator(IManifestPopulator):
     @staticmethod
     def _variable_to_manifest_path(var):
         var_to_path_dict = {"name": ["metadata", "name"],
-                            "label": ["metadata", "labels", "tag"],
+                            "label": ["metadata", "labels", "userLabel"],
                             "arguments": ["spec", "arguments"],
                             "language": ["spec", "type"],
                             "python_version": ["spec", "pythonVersion"],

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
@@ -5,6 +5,7 @@ from PiezoWebApp.src.utils.dict_argument_helper import set_value_in_nested_dict
 class ManifestPopulator(IManifestPopulator):
     def __init__(self, configuration, validation_rules):
         self._validation_rules = validation_rules
+        self._arguments = self._validation_rules.get_default_value_for_key("arguments")
         self._api_version = self._validation_rules.get_default_value_for_key("apiVersion")
         self._kind = self._validation_rules.get_default_value_for_key("kind")
         self._metadata_name = self._validation_rules.get_default_value_for_key("name")
@@ -87,6 +88,7 @@ class ManifestPopulator(IManifestPopulator):
     @staticmethod
     def _variable_to_manifest_path(var):
         var_to_path_dict = {"name": ["metadata", "name"],
+                            "arguments": ["spec", "arguments"],
                             "language": ["spec", "type"],
                             "python_version": ["spec", "pythonVersion"],
                             "main_class": ["spec", "mainClass"],

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
@@ -10,6 +10,7 @@ class ManifestPopulator(IManifestPopulator):
         self._kind = self._validation_rules.get_default_value_for_key("kind")
         self._metadata_name = self._validation_rules.get_default_value_for_key("name")
         self._metadata_namespace = self._validation_rules.get_default_value_for_key("namespace")
+        self._metadata_label = self._validation_rules.get_default_value_for_key("label")
         self._spec_type = self._validation_rules.get_default_value_for_key("language")
         self._spec_mode = self._validation_rules.get_default_value_for_key("mode")
         self._spec_python_version = self._validation_rules.get_default_value_for_key("python_version")
@@ -21,11 +22,13 @@ class ManifestPopulator(IManifestPopulator):
         self._spec_restart_policy_type = self._validation_rules.get_default_value_for_key("restart_policy")
         self._spec_driver_cores = self._validation_rules.get_default_value_for_key("driver_cores")
         self._spec_driver_memory = self._validation_rules.get_default_value_for_key("driver_memory")
+        self._spec_driver_label_custom = self._validation_rules.get_default_value_for_key("label")
         self._spec_driver_label_version = self._validation_rules.get_default_value_for_key("spark_version")
         self._spec_driver_service_account = self._validation_rules.get_default_value_for_key("service_account")
         self._spec_executor_instances = self._validation_rules.get_default_value_for_key("executors")
         self._spec_executor_cores = self._validation_rules.get_default_value_for_key("executor_cores")
         self._spec_executor_memory = self._validation_rules.get_default_value_for_key("executor_memory")
+        self._spec_executor_label_custom = self._validation_rules.get_default_value_for_key("label")
         self._spec_executor_label_version = self._validation_rules.get_default_value_for_key("spark_version")
         self._s3_endpoint = configuration.s3_endpoint
         self._secret_name = configuration.s3_secrets_name
@@ -62,7 +65,8 @@ class ManifestPopulator(IManifestPopulator):
                         "cores": self._spec_driver_cores,
                         "memory": self._spec_driver_memory,
                         "labels": {
-                            "version": self._spec_driver_label_version},
+                            "version": self._spec_driver_label_version,
+                            "tag": self._spec_driver_label_custom},
                         "serviceAccount": self._spec_driver_service_account,
                         "envSecretKeyRefs": {
                             "AWS_ACCESS_KEY_ID": {
@@ -76,7 +80,8 @@ class ManifestPopulator(IManifestPopulator):
                         "instances": self._spec_executor_instances,
                         "memory": self._spec_executor_memory,
                         "labels": {
-                            "version": self._spec_executor_label_version},
+                            "version": self._spec_executor_label_version,
+                            "tag": self._spec_executor_label_custom},
                         "envSecretKeyRefs": {
                             "AWS_ACCESS_KEY_ID": {
                                 "name": self._secret_name,
@@ -88,6 +93,7 @@ class ManifestPopulator(IManifestPopulator):
     @staticmethod
     def _variable_to_manifest_path(var):
         var_to_path_dict = {"name": ["metadata", "name"],
+                            "label": ["metadata", "labels", "tag"],
                             "arguments": ["spec", "arguments"],
                             "language": ["spec", "type"],
                             "python_version": ["spec", "pythonVersion"],

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/validation_ruleset.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/validation_ruleset.py
@@ -10,7 +10,6 @@ class ValidationRuleset:
         return validation_rule.default
 
     def get_key_type_pairs_allowed_as_input(self):
-        # TODO variable type other than string
         return {key: self._validation_dict[key].type for key in self._validation_dict.keys()}
 
     def get_keys_for_language(self, language):

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/validation_ruleset.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/validation_ruleset.py
@@ -11,7 +11,7 @@ class ValidationRuleset:
 
     def get_key_type_pairs_allowed_as_input(self):
         # TODO variable type other than string
-        return {key: 'string' for key in self._validation_dict.keys()}
+        return {key: self._validation_dict[key]['type'] for key in self._validation_dict.keys()}
 
     def get_keys_for_language(self, language):
         return [

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/validation_ruleset.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/validation_ruleset.py
@@ -11,7 +11,7 @@ class ValidationRuleset:
 
     def get_key_type_pairs_allowed_as_input(self):
         # TODO variable type other than string
-        return {key: self._validation_dict[key]['type'] for key in self._validation_dict.keys()}
+        return {key: self._validation_dict[key].type for key in self._validation_dict.keys()}
 
     def get_keys_for_language(self, language):
         return [

--- a/piezo_web_app/PiezoWebApp/src/utils/dict_argument_helper.py
+++ b/piezo_web_app/PiezoWebApp/src/utils/dict_argument_helper.py
@@ -5,6 +5,8 @@ def get_set_difference(first, second):
 def set_value_in_nested_dict(nested_dict, path, value):
     current_dict = nested_dict
     for i in range(len(path) - 1):
+        if path[i] not in current_dict:
+            current_dict[path[i]] = {}
         current_dict = current_dict[path[i]]
     current_dict[path[len(path) - 1]] = value
     return nested_dict

--- a/piezo_web_app/PiezoWebApp/tests/handlers/base_handler_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/base_handler_test.py
@@ -37,7 +37,8 @@ class BaseHandlerTest(AsyncHTTPTestCase, metaclass=ABCMeta):
             'driver_memory': 'string',
             'executors': 'string',
             'executor_cores': 'string',
-            'executor_memory': 'string'
+            'executor_memory': 'string',
+            'arguments': 'array'
         }
         self.mock_validation_ruleset.get_keys_of_required_inputs.return_value = [
             'name',

--- a/piezo_web_app/PiezoWebApp/tests/handlers/schema/schema_helpers_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/schema/schema_helpers_test.py
@@ -51,12 +51,13 @@ def test_create_object_schema_from_validation_ruleset_returns_schema_with_all_re
     }
 
 
-def test_create_object_schema_from_validation_ruleset_returns_expected_schema_with_mixed_rules():
+def test_create_object_schema_from_validation_ruleset_returns_expected_schema_with_mixed_rules_and_mixed_types():
     # Arrange
     ruleset = mock.create_autospec(ValidationRuleset)
     ruleset.get_key_type_pairs_allowed_as_input.return_value = {
         'required': 'string',
         'optional': 'string',
+        'optional2': 'array',
         'conditional': 'string'
     }
     ruleset.get_keys_of_required_inputs.return_value = ['required']
@@ -68,6 +69,7 @@ def test_create_object_schema_from_validation_ruleset_returns_expected_schema_wi
         'properties': {
             'required': {'type': 'string'},
             'optional': {'type': 'string'},
+            'optional2': {'type': 'array'},
             'conditional': {'type': 'string'}
         },
         'required': ['required']

--- a/piezo_web_app/PiezoWebApp/tests/handlers/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/submit_job_test.py
@@ -67,7 +67,8 @@ class TestSubmitJobHandler(BaseHandlerTest):
             'language': 'test-language',
             'path_to_main_app_file': '/path/to/main/app.file',
             'driver_cores': '1',
-            'driver_memory': '1024m'
+            'driver_memory': '1024m',
+            'arguments': ["arg1", "arg2", 10]
         }
         self.mock_spark_job_service.submit_job.return_value = {
             'status': StatusCodes.Okay.value,

--- a/piezo_web_app/PiezoWebApp/tests/handlers/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/submit_job_test.py
@@ -68,7 +68,8 @@ class TestSubmitJobHandler(BaseHandlerTest):
             'path_to_main_app_file': '/path/to/main/app.file',
             'driver_cores': '1',
             'driver_memory': '1024m',
-            'arguments': ["arg1", "arg2", 10]
+            'arguments': ["arg1", "arg2", 10],
+            'lable': 'my_label'
         }
         self.mock_spark_job_service.submit_job.return_value = {
             'status': StatusCodes.Okay.value,

--- a/piezo_web_app/PiezoWebApp/tests/handlers/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/submit_job_test.py
@@ -82,7 +82,7 @@ class TestSubmitJobHandler(BaseHandlerTest):
         assert response_code == 200
 
     @gen_test
-    def test_post_returns_400_error_when_optional_inputs_are_not_strings(self):
+    def test_post_returns_400_error_when_optional_string_inputs_are_not_strings(self):
         # Arrange
         body = {
             'name': 'test-spark-job',
@@ -90,6 +90,25 @@ class TestSubmitJobHandler(BaseHandlerTest):
             'path_to_main_app_file': '/path/to/main/app.file',
             'driver_cores': 0.8,
             'driver_memory': 1024
+        }
+        self.mock_spark_job_service.submit_job.return_value = {
+            'status': StatusCodes.Okay.value,
+            'message': 'Job driver created successfully',
+            'driver_name': 'test-spark-job-driver'
+        }
+        # Act
+        yield self.assert_request_returns_400(body)
+        # Assert
+        self.mock_spark_job_service.submit_job.assert_not_called()
+
+    @gen_test
+    def test_post_returns_400_error_when_optional_array_inputs_are_not_arrays(self):
+        # Arrange
+        body = {
+            'name': 'test-spark-job',
+            'language': 'test-language',
+            'path_to_main_app_file': '/path/to/main/app.file',
+            'arguments': 11
         }
         self.mock_spark_job_service.submit_job.return_value = {
             'status': StatusCodes.Okay.value,

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/example_validation_rules.json
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/example_validation_rules.json
@@ -109,5 +109,9 @@
     "default": "512m",
     "minimum": 512,
     "maximum": 4096
+  },
+  {
+    "input_name": "label",
+    "classification": "Optional"
   }
 ]

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/example_validation_rules.json
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/example_validation_rules.json
@@ -1,5 +1,10 @@
 [
   {
+    "input_name": "arguments",
+    "classification": "Optional",
+    "type": "array"
+  },
+  {
     "input_name": "apiVersion",
     "classification": "Fixed",
     "default": "sparkoperator.k8s.io/v1beta1"

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/example_validation_rules.json
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/example_validation_rules.json
@@ -1,10 +1,5 @@
 [
   {
-    "input_name": "arguments",
-    "classification": "Optional",
-    "type": "array"
-  },
-  {
     "input_name": "apiVersion",
     "classification": "Fixed",
     "default": "sparkoperator.k8s.io/v1beta1"
@@ -74,6 +69,11 @@
     "classification": "Conditional",
     "conditional_input_name": "language",
     "conditional_input_value": "Scala"
+  },
+  {
+    "input_name": "arguments",
+    "classification": "Optional",
+    "type": "array"
   },
   {
     "input_name": "driver_cores",

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
@@ -33,7 +33,8 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'name': 'test_python_job',
             'language': 'Python',
             'path_to_main_app_file': '/path_to/file',
-            'python_version': '2'
+            'python_version': '2',
+            'arguments': ["1000"]
         }
         kubernetes_response = {'metadata': {'name': 'test_python_job'}}
         self.mock_k8s_adapter.create_namespaced_custom_object.return_value = kubernetes_response
@@ -56,8 +57,9 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
                 'mainApplicationFile': '/path_to/file',
                 'sparkVersion': '2.4.0',
                 'restartPolicy': {'type': 'Never'},
-                "hadoopConf": {
-                    "fs.s3a.endpoint": "0.0.0.0"},
+                'hadoopConf': {
+                    'fs.s3a.endpoint': '0.0.0.0'},
+                'arguments': ['1000'],
                 'driver': {
                     'cores': 0.1,
                     'memory': '512m',
@@ -109,7 +111,8 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'name': 'test_scala_job',
             'language': 'Scala',
             'path_to_main_app_file': '/path_to/file',
-            'main_class': 'main.class'
+            'main_class': 'main.class',
+            'arguments': ["1000"]
         }
         kubernetes_response = {'metadata': {'name': 'test_scala_job'}}
         self.mock_k8s_adapter.create_namespaced_custom_object.return_value = kubernetes_response
@@ -132,8 +135,9 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
                 'mainApplicationFile': '/path_to/file',
                 'sparkVersion': '2.4.0',
                 'restartPolicy': {'type': 'Never'},
-                "hadoopConf": {
-                    "fs.s3a.endpoint": "0.0.0.0"},
+                'hadoopConf': {
+                    'fs.s3a.endpoint': '0.0.0.0'},
+                'arguments': ['1000'],
                 'driver': {
                     'cores': 0.1,
                     'memory': '512m',

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
@@ -194,7 +194,8 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'driver_memory': '2048m',
             'executors': '10',
             'executor_cores': '4',
-            'executor_memory': '4096m'
+            'executor_memory': '4096m',
+            'label': 'my_label'
         }
         kubernetes_response = {'metadata': {'name': 'test_python_job'}}
         self.mock_k8s_adapter.create_namespaced_custom_object.return_value = kubernetes_response
@@ -206,7 +207,10 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'kind': 'SparkApplication',
             'metadata': {
                 'name': 'test_python_job',
-                'namespace': 'default'
+                'namespace': 'default',
+                'labels': {
+                    'userLabel': 'my_label'
+                }
             },
             'spec': {
                 'type': 'Python',

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/argument_validator_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/argument_validator_test.py
@@ -386,4 +386,3 @@ def test_validate_label_rejects_empty_strings_and_non_strings(label):
     validation_result = argument_validator.validate("label", label, validation_rule)
     # Assert
     assert validation_result.is_valid is False
-

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/argument_validator_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/argument_validator_test.py
@@ -366,3 +366,24 @@ def test_validate_executor_memory_rejects_incorrectly_formatted_values(memory):
     assert validation_result.is_valid is False
     assert validation_result.message == '"executor_memory" input must be a string integer value ending in "m" ' \
                                         '(e.g. "512m" for 512 megabytes)'
+
+
+@pytest.mark.parametrize("label", ["someLabel", "12321"])
+def test_validate_label_validates_non_empty_strings(label):
+    # Arrange
+    validation_rule = ValidationRule({'classification': 'Optional'})
+    # Act
+    validation_result = argument_validator.validate("label", label, validation_rule)
+    # Assert
+    assert validation_result.is_valid is True
+
+
+@pytest.mark.parametrize("label", [" ", "", 123323, None])
+def test_validate_label_rejects_empty_strings_and_non_strings(label):
+    # Arrange
+    validation_rule = ValidationRule({'classification': 'Optional'})
+    # Act
+    validation_result = argument_validator.validate("label", label, validation_rule)
+    # Assert
+    assert validation_result.is_valid is False
+

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/manifest_populator_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/manifest_populator_test.py
@@ -36,7 +36,8 @@ class TestTemplatePopulator(unittest.TestCase):
                 'driver_memory': "512m",
                 'executors': 1,
                 'executor_cores': 1,
-                'executor_memory': "512m"
+                'executor_memory': "512m",
+                'label': None
             }[input_name]
         self.test_populator = ManifestPopulator(mock_configuration, mock_validation_ruleset)
         self.arguments = {"name": "test",
@@ -46,7 +47,8 @@ class TestTemplatePopulator(unittest.TestCase):
                           "executor_cores": "1",
                           "executors": "1",
                           "executor_memory": "512m",
-                          "arguments": ["1000", "100"]}
+                          "arguments": ["1000", "100"],
+                          "label": "myLabel"}
 
     def test_build_manifest_builds_python_job_manifest_for_python_applications(self):
         # Arrange
@@ -59,7 +61,9 @@ class TestTemplatePopulator(unittest.TestCase):
                                         "kind": "SparkApplication",
                                         "metadata":
                                             {"name": "test",
-                                             "namespace": "default"},
+                                             "namespace": "default",
+                                             "labels": {
+                                                 "userLabel": "myLabel"}},
                                         "spec": {
                                             "type": "Python",
                                             "pythonVersion": "2",
@@ -111,7 +115,9 @@ class TestTemplatePopulator(unittest.TestCase):
                                         "kind": "SparkApplication",
                                         "metadata":
                                             {"name": "test",
-                                             "namespace": "default"},
+                                             "namespace": "default",
+                                             "labels": {
+                                                 "userLabel": "myLabel"}},
                                         "spec": {
                                             "type": "Scala",
                                             "mode": "cluster",

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/manifest_populator_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/manifest_populator_test.py
@@ -31,6 +31,7 @@ class TestTemplatePopulator(unittest.TestCase):
                 'language': None,
                 'python_version': None,
                 'main_class': None,
+                'arguments': None,
                 'driver_cores': 0.1,
                 'driver_memory': "512m",
                 'executors': 1,
@@ -44,7 +45,8 @@ class TestTemplatePopulator(unittest.TestCase):
                           "driver_memory": "512m",
                           "executor_cores": "1",
                           "executors": "1",
-                          "executor_memory": "512m"}
+                          "executor_memory": "512m",
+                          "arguments": ["1000", "100"]}
 
     def test_build_manifest_builds_python_job_manifest_for_python_applications(self):
         # Arrange
@@ -70,6 +72,7 @@ class TestTemplatePopulator(unittest.TestCase):
                                                 "type": "Never"},
                                             "hadoopConf": {
                                                 "fs.s3a.endpoint": "0.0.0.0"},
+                                            "arguments": ["1000", "100"],
                                             "driver": {
                                                 "cores": "0.1",
                                                 "memory": "512m",
@@ -121,6 +124,7 @@ class TestTemplatePopulator(unittest.TestCase):
                                                 "type": "Never"},
                                             "hadoopConf": {
                                                 "fs.s3a.endpoint": "0.0.0.0"},
+                                            "arguments": ["1000", "100"],
                                             "driver": {
                                                 "cores": "0.1",
                                                 "memory": "512m",

--- a/piezo_web_app/PiezoWebApp/tests/utils/dict_argument_helper_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/utils/dict_argument_helper_test.py
@@ -103,14 +103,15 @@ def test_set_value_in_nested_dict_overwrites_value_that_already_exists():
     assert result == {"a": 1, "b": {"c": 2}, "d": {"e": {"f": 3, "g": 5}}}
 
 
-def test_set_value_in_nested_dict_throw_an_error_if_path_not_in_nested_dict():
+def test_set_value_in_nested_dict_adds_path_not_in_nested_dict():
     # Arrange
     path = ["x", "z", "g"]
     nested_dict = {"a": 1, "b": {"c": 2}, "d": {"e": {"f": 3}}}
     value = 5
     # Act
-    with pytest.raises(KeyError):
-        set_value_in_nested_dict(nested_dict, path, value)
+    result = set_value_in_nested_dict(nested_dict, path, value)
+    # Assert
+    assert result == {"a": 1, "b": {"c": 2}, "d": {"e": {"f": 3}}, "x": {"z": {"g": 5}}}
 
 
 def test_set_value_in_nested_dict_throw_an_error_if_no_path_given():

--- a/piezo_web_app/PiezoWebApp/tests/utils/validation_ruleset_parser_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/utils/validation_ruleset_parser_test.py
@@ -52,6 +52,11 @@ def test_validation_rules_parser_parses_with_arguments():
             'input_name': 'conditional_with_options',
             'classification': 'Conditional',
             'options': ['option1', 'option2']
+        },
+        {
+            'input_name': 'optional_type_array',
+            'classification': 'Optional',
+            'type': 'array'
         }
     ])
     # Act
@@ -63,6 +68,7 @@ def test_validation_rules_parser_parses_with_arguments():
     required_no_default = rules['required_no_default']
     assert required_no_default.classification is ArgumentClassification.Required
     assert required_no_default.default is None
+    assert required_no_default.type == 'string'
     optional_with_range = rules['optional_with_range']
     assert optional_with_range.classification is ArgumentClassification.Optional
     assert optional_with_range.minimum == 1
@@ -70,5 +76,8 @@ def test_validation_rules_parser_parses_with_arguments():
     conditional_with_options = rules['conditional_with_options']
     assert conditional_with_options.classification is ArgumentClassification.Conditional
     assert conditional_with_options.options == ['option1', 'option2']
+    optional_type_array = rules['optional_type_array']
+    assert optional_type_array.classification is ArgumentClassification.Optional
+    assert optional_type_array.type == 'array'
     # Clean up
     SampleValidationRulesCreator.remove_file(rules_path)


### PR DESCRIPTION
Adding optional argument when submitting a job of `label`. This label can be used to filter the sparkapplications on kubernetes. The label has the key `userLabel` and is only present if specified. All system tests run with the label `userLabel=systemTest`

**Note this branch was built off #45 which should be merged in before this one**

### Use case:
Cleaning up system tests after running: `kubectl delete sparkapplications -l userLabel=systemTest`
Potentially used as a unique identifier in the future where could be used as the user name .

### To test:
* Run unit and system tests.
* Run a seperate job through postman  without the systemtest label
* `kubectl delete sparkapplications -l userLabel=systemTest` check only system test jobs are deleted and not the one run through postman


### Stories covered
#52 