### PR TITLE
Feature/job names unique#51

### DIFF
--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -77,14 +77,14 @@ Submit Wordcount On Minio Job
     # big.txt and wordcount.py must both exist on minio in the bucket kubernetes before running this test
     [Arguments]   ${job_name}
     ${arguments}=   Create List   s3a://kubernetes/inputs/big.txt    s3a://kubernetes/outputs/${job_name}
-    ${submitbody}=    Create Dictionary   name=${job_name}   language=Python   python_version=2    path_to_main_app_file=s3a://kubernetes/inputs/wordcount.py     label=systemTest      arguments=${arguments}
+    ${submitbody}=    Create Dictionary   name=${job_name}   language=Python   python_version=2    path_to_main_app_file=s3a://kubernetes/inputs/wordcount.py     label=systemTest      arguments=${arguments}    executors=4
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
     [return]  ${response}
 
 Wait For Spark Job To Finish
-    [Arguments]    ${job_name}
+    [Arguments]    ${job_name}    ${step_size}
     :For    ${i}    IN RANGE   0    24
-    \   Sleep     5 seconds
+    \   Sleep     ${step_size}
     \   ${response}=   Get Status Of Spark Job   ${job_name}
     \   ${message}=  Get Response Data Message     ${response}
     \   ${finished}=    Set Variable If     '${message}'=='COMPLETED'   ${True}     ${False}

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -56,7 +56,7 @@ Can Get Logs Of Submitted Spark Job
     ${job_name}=     Set Variable   spark-pi-fe244
     ${response}=    Submit SparkPi Job    ${job_name}
     ${job_name}=    Get Response Job Name   ${response}
-    ${finished}=    Wait For Spark Job To Finish        ${job_name}
+    ${finished}=    Wait For Spark Job To Finish        ${job_name}     5 seconds
     Should Be True      ${finished}
     ${response}=  Get Logs For Spark Job    ${job_name}
     ${joblog}=    Get Response Data Message   ${response}
@@ -69,7 +69,7 @@ Arguments Have Been Read And Appear In Logs
     ${response}=    Submit SparkGroupByTest Job With Arguments   ${job_name}
     ${job_name}=    Get Response Job Name   ${response}
     Confirm Ok Response  ${response}
-    ${finished}=    Wait For Spark Job To Finish        ${job_name}
+    ${finished}=    Wait For Spark Job To Finish        ${job_name}     5 seconds
     Should Be True      ${finished}
     ${logresponse}=  Get Logs For Spark Job    ${job_name}
     ${joblog}=  Get Response Data Message   ${logresponse}
@@ -84,7 +84,7 @@ Can Delete Submitted Spark Job
     ${job_name}=    Set Variable        spark-pi-83783
     ${response}=    Submit SparkPi Job   ${job_name}
     ${job_name}=    Get Response Job Name   ${response}
-    ${finished}=    Wait For Spark Job To Finish        ${job_name}
+    ${finished}=    Wait For Spark Job To Finish        ${job_name}     5 seconds
     Should Be True    ${finished}
     ${response}=  Delete Spark Job    ${job_name}
     Confirm Ok Response   ${response}
@@ -103,7 +103,7 @@ Job Can Use Data And Code On S3 And Write Back Results
     ${response}=    Submit Wordcount On Minio Job   ${job_name}
     Confirm Ok Response  ${response}
     ${job_name}=    Get Response Job Name   ${response}
-    ${finished}=    Wait For Spark Job To Finish        ${job_name}
+    ${finished}=    Wait For Spark Job To Finish        ${job_name}     15 seconds
     Should Be True    ${finished}
     Directory Should Exist In S3 Bucket   kubernetes    outputs/${job_name}
     Directory Should Not Be Empty In S3 bucket  kubernetes    outputs/${job_name}

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -44,6 +44,12 @@ Submit Spark Pi Job Returns Ok Response
     ${message}=   Get Response Data Message   ${response}
     Should Be Equal As Strings    ${message}    Job driver created successfully
 
+Submit Two Jobs With Same Name Returns Ok Responses
+    ${response1}=   Submit SparkPi Job    twin-job
+    ${response2}=   Submit SparkPi Job    twin-job
+    Confirm Ok Response  ${response1}
+    Confirm Ok Response  ${response2}
+
 Submit GroupByTest Spark Job With Arguments Returns Ok Response
     ${response}=    Submit SparkGroupByTest Job With Arguments   spark-group-by-test
     Confirm Ok Response  ${response}

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -102,8 +102,8 @@ Job Can Use Data And Code On S3 And Write Back Results
     Directory Should Not Exist In S3 Bucket   kubernetes    outputs/${job_name}
     ${response}=    Submit Wordcount On Minio Job   ${job_name}
     Confirm Ok Response  ${response}
-    ${job_name}=    Get Response Job Name   ${response}
-    ${finished}=    Wait For Spark Job To Finish        ${job_name}     15 seconds
+    ${new_job_name}=    Get Response Job Name   ${response}
+    ${finished}=    Wait For Spark Job To Finish        ${new_job_name}     15 seconds
     Should Be True    ${finished}
     Directory Should Exist In S3 Bucket   kubernetes    outputs/${job_name}
     Directory Should Not Be Empty In S3 bucket  kubernetes    outputs/${job_name}

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -39,20 +39,23 @@ Delete Job Of Non Job Returns Not Found Response
 Submit Spark Pi Job Returns Ok Response
     ${response}=    Submit SparkPi Job    spark-pi-3f69c
     Confirm Ok Response  ${response}
-    ${data}=    Get Response Data   ${response}
-    Should Be Equal As Strings    ${data["message"]}    Job driver created successfully
-    Should Be Equal As Strings    ${data["driver_name"]}   spark-pi-3f69c-driver
+    ${job_name}=    Get Response Job Name   ${response}
+    Should Match Regexp   ${job_name}   spark-pi-3f69c-[a-z0-9]{5}
+    ${message}=   Get Response Data Message   ${response}
+    Should Be Equal As Strings    ${message}    Job driver created successfully
 
 Submit GroupByTest Spark Job With Arguments Returns Ok Response
     ${response}=    Submit SparkGroupByTest Job With Arguments   spark-group-by-test-8s2xp
     Confirm Ok Response  ${response}
-    ${data}=    Get Response Data   ${response}
-    Should Be Equal As Strings    ${data["message"]}    Job driver created successfully
-    Should Be Equal As Strings    ${data["driver_name"]}   spark-group-by-test-8s2xp-driver
+    ${job_name}=    Get Response Job Name   ${response}
+    Should Match Regexp   ${job_name}   spark-group-by-test-8s2xp-[a-z0-9]{5}
+    ${message}=   Get Response Data Message   ${response}
+    Should Be Equal As Strings    ${message}    Job driver created successfully
 
 Can Get Logs Of Submitted Spark Job
     ${job_name}=     Set Variable   spark-pi-fe244
-    Submit SparkPi Job    ${job_name}
+    ${response}=    Submit SparkPi Job    ${job_name}
+    ${job_name}=    Get Response Job Name   ${response}
     ${finished}=    Wait For Spark Job To Finish        ${job_name}
     Should Be True      ${finished}
     ${response}=  Get Logs For Spark Job    ${job_name}
@@ -64,6 +67,7 @@ Can Get Logs Of Submitted Spark Job
 Arguments Have Been Read And Appear In Logs
     ${job_name}=  Set Variable  spark-group-by-test-3ewc7
     ${response}=    Submit SparkGroupByTest Job With Arguments   ${job_name}
+    ${job_name}=    Get Response Job Name   ${response}
     Confirm Ok Response  ${response}
     ${finished}=    Wait For Spark Job To Finish        ${job_name}
     Should Be True      ${finished}
@@ -78,7 +82,8 @@ Arguments Have Been Read And Appear In Logs
 
 Can Delete Submitted Spark Job
     ${job_name}=    Set Variable        spark-pi-83783
-    Submit SparkPi Job   ${job_name}
+    ${response}=    Submit SparkPi Job   ${job_name}
+    ${job_name}=    Get Response Job Name   ${response}
     ${finished}=    Wait For Spark Job To Finish        ${job_name}
     Should Be True    ${finished}
     ${response}=  Delete Spark Job    ${job_name}
@@ -86,7 +91,8 @@ Can Delete Submitted Spark Job
 
 Can Get Status Of Submitted Spark Job
     ${job_name}=     Set Variable       spark-pi-5jk23s
-    Submit SparkPi Job    ${job_name}
+    ${response}=    Submit SparkPi Job    ${job_name}
+    ${job_name}=    Get Response Job Name   ${response}
     Sleep       5 seconds
     ${response}=  Get Status Of Spark Job   ${job_name}
     Confirm Ok Response     ${response}
@@ -96,6 +102,7 @@ Job Can Use Data And Code On S3 And Write Back Results
     Directory Should Not Exist In S3 Bucket   kubernetes    outputs/${job_name}
     ${response}=    Submit Wordcount On Minio Job   ${job_name}
     Confirm Ok Response  ${response}
+    ${job_name}=    Get Response Job Name   ${response}
     ${finished}=    Wait For Spark Job To Finish        ${job_name}
     Should Be True    ${finished}
     Directory Should Exist In S3 Bucket   kubernetes    outputs/${job_name}

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -37,23 +37,23 @@ Delete Job Of Non Job Returns Not Found Response
     Confirm Not Found Response  ${response}
 
 Submit Spark Pi Job Returns Ok Response
-    ${response}=    Submit SparkPi Job    spark-pi-3f69c
+    ${response}=    Submit SparkPi Job    spark-pi
     Confirm Ok Response  ${response}
     ${job_name}=    Get Response Job Name   ${response}
-    Should Match Regexp   ${job_name}   spark-pi-3f69c-[a-z0-9]{5}
+    Should Match Regexp   ${job_name}   spark-pi-[a-z0-9]{5}
     ${message}=   Get Response Data Message   ${response}
     Should Be Equal As Strings    ${message}    Job driver created successfully
 
 Submit GroupByTest Spark Job With Arguments Returns Ok Response
-    ${response}=    Submit SparkGroupByTest Job With Arguments   spark-group-by-test-8s2xp
+    ${response}=    Submit SparkGroupByTest Job With Arguments   spark-group-by-test
     Confirm Ok Response  ${response}
     ${job_name}=    Get Response Job Name   ${response}
-    Should Match Regexp   ${job_name}   spark-group-by-test-8s2xp-[a-z0-9]{5}
+    Should Match Regexp   ${job_name}   spark-group-by-test-[a-z0-9]{5}
     ${message}=   Get Response Data Message   ${response}
     Should Be Equal As Strings    ${message}    Job driver created successfully
 
 Can Get Logs Of Submitted Spark Job
-    ${job_name}=     Set Variable   spark-pi-fe244
+    ${job_name}=     Set Variable   spark-pi
     ${response}=    Submit SparkPi Job    ${job_name}
     ${job_name}=    Get Response Job Name   ${response}
     ${finished}=    Wait For Spark Job To Finish        ${job_name}     5 seconds
@@ -65,7 +65,7 @@ Can Get Logs Of Submitted Spark Job
     Should Be Equal As Integers   ${num_pi_lines}   1
 
 Arguments Have Been Read And Appear In Logs
-    ${job_name}=  Set Variable  spark-group-by-test-3ewc7
+    ${job_name}=  Set Variable  spark-group-by-test
     ${response}=    Submit SparkGroupByTest Job With Arguments   ${job_name}
     ${job_name}=    Get Response Job Name   ${response}
     Confirm Ok Response  ${response}
@@ -81,7 +81,7 @@ Arguments Have Been Read And Appear In Logs
     Should Be Equal As Integers   ${num_arg_4_lines}   1
 
 Can Delete Submitted Spark Job
-    ${job_name}=    Set Variable        spark-pi-83783
+    ${job_name}=    Set Variable        spark-pi
     ${response}=    Submit SparkPi Job   ${job_name}
     ${job_name}=    Get Response Job Name   ${response}
     ${finished}=    Wait For Spark Job To Finish        ${job_name}     5 seconds
@@ -90,7 +90,7 @@ Can Delete Submitted Spark Job
     Confirm Ok Response   ${response}
 
 Can Get Status Of Submitted Spark Job
-    ${job_name}=     Set Variable       spark-pi-5jk23s
+    ${job_name}=     Set Variable       spark-pi
     ${response}=    Submit SparkPi Job    ${job_name}
     ${job_name}=    Get Response Job Name   ${response}
     Sleep       5 seconds
@@ -98,7 +98,7 @@ Can Get Status Of Submitted Spark Job
     Confirm Ok Response     ${response}
 
 Job Can Use Data And Code On S3 And Write Back Results
-    ${job_name}=    Set Variable      wordcount-9lkw3w
+    ${job_name}=    Set Variable      wordcount
     Directory Should Not Exist In S3 Bucket   kubernetes    outputs/${job_name}
     ${response}=    Submit Wordcount On Minio Job   ${job_name}
     Confirm Ok Response  ${response}

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -50,6 +50,12 @@ Submit Two Jobs With Same Name Returns Ok Responses
     Confirm Ok Response  ${response1}
     Confirm Ok Response  ${response2}
 
+Submit Job With 200 Character Name Runs Successfully
+    ${response}=    Submit SparkPi Job    abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy
+    Confirm Ok Response  ${response}
+    ${finished}=    Wait For Spark Job To Finish        ${job_name}     5 seconds
+    Should Be True      ${finished}
+
 Submit GroupByTest Spark Job With Arguments Returns Ok Response
     ${response}=    Submit SparkGroupByTest Job With Arguments   spark-group-by-test
     Confirm Ok Response  ${response}

--- a/SystemTests/roles/robot/files/requests_helpers.robot
+++ b/SystemTests/roles/robot/files/requests_helpers.robot
@@ -24,6 +24,10 @@ Get Response Data Message
   [Arguments]   ${response}
   [return]    ${response.json()["data"]["message"]}
 
+Get Response Job Name
+  [Arguments]   ${response}
+  [return]    ${response.json()["data"]["job_name"]}
+
 Json Header
   ${header}=  Create Dictionary   Content-Type=application/json
   [return]    ${header}

--- a/piezo_web_app/PiezoWebApp/run_piezo.py
+++ b/piezo_web_app/PiezoWebApp/run_piezo.py
@@ -10,6 +10,7 @@ from PiezoWebApp.src.handlers.heartbeat_handler import HeartbeatHandler
 from PiezoWebApp.src.handlers.submit_job import SubmitJobHandler
 from PiezoWebApp.src.handlers.job_status import JobStatusHandler
 from PiezoWebApp.src.services.kubernetes.kubernetes_adapter import KubernetesAdapter
+from PiezoWebApp.src.services.spark_job.spark_job_namer import SparkJobNamer
 from PiezoWebApp.src.services.spark_job.spark_job_service import SparkJobService
 from PiezoWebApp.src.services.spark_job.validation.manifest_populator import ManifestPopulator
 from PiezoWebApp.src.services.spark_job.validation.validation_ruleset import ValidationRuleset
@@ -55,7 +56,8 @@ def build_container(configuration, k8s_adapter, log, validation_rules_path):
     validation_ruleset = ValidationRuleset(validation_rules)
     validation_service = ValidationService(validation_ruleset)
     manifest_populator = ManifestPopulator(configuration, validation_ruleset)
-    spark_job_service = SparkJobService(k8s_adapter, log, manifest_populator, validation_service)
+    spark_job_namer = SparkJobNamer(k8s_adapter, validation_ruleset)
+    spark_job_service = SparkJobService(k8s_adapter, log, manifest_populator, spark_job_namer, validation_service)
     container = dict(
         logger=log,
         spark_job_service=spark_job_service,
@@ -74,7 +76,6 @@ def build_app(container, use_route_stem=False):
             (format_route_specification(route_stem + 'getlogs'), GetLogsHandler, container),
             (format_route_specification(route_stem + 'jobstatus'), JobStatusHandler, container),
             (format_route_specification(route_stem + 'submitjob'), SubmitJobHandler, container)
-
         ]
     )
     return app

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_namer.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_namer.py
@@ -1,0 +1,8 @@
+from abc import ABCMeta, abstractmethod
+
+
+class ISparkJobNamer(metaclass=ABCMeta):
+
+    @abstractmethod
+    def rename_job(self, base_name):
+        pass

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
@@ -12,7 +12,7 @@ class ISparkJobService(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_logs(self, driver_name, namespace):
+    def get_logs(self, job_name, namespace):
         pass
 
     @abstractmethod

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_constants.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_constants.py
@@ -1,0 +1,8 @@
+# str | The custom resource's group name
+CRD_GROUP = 'sparkoperator.k8s.io'
+
+# str | The custom resource's plural name. For TPRs this would be lowercase plural kind.
+CRD_PLURAL = 'sparkapplications'
+
+# str | The custom resource's version
+CRD_VERSION = 'v1beta1'

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
@@ -39,5 +39,9 @@ class SparkJobNamer(ISparkJobNamer):
 
     @staticmethod
     def _tag_job_name_with_uuid(base_name):
-        uuid_tag = uuid.uuid4()
+        # UUIDs are sequences of 32 hexadecimal digits separated by hyphens
+        # 32 hexadecimal digits have a total number of possible combinations that is over 3.4E38
+        # Here we trim the UUID to just 8 hexadecimal digits
+        # 16 hexadecimal digits have a total number of possible combinations that is over 4.2E9
+        uuid_tag = str(uuid.uuid4())[:8]
         return f'{base_name}-{uuid_tag}'

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
@@ -1,0 +1,43 @@
+from kubernetes.client.rest import ApiException
+from uuid import uuid4
+
+from PiezoWebApp.src.services.spark_job.i_spark_job_namer import ISparkJobNamer
+from PiezoWebApp.src.services.spark_job.spark_job_constants import CRD_GROUP
+from PiezoWebApp.src.services.spark_job.spark_job_constants import CRD_PLURAL
+from PiezoWebApp.src.services.spark_job.spark_job_constants import CRD_VERSION
+
+
+class SparkJobNamer(ISparkJobNamer):
+    def __init__(self, kubernetes_adapter, validation_ruleset):
+        self._namespace = validation_ruleset.get_default_value_for_key("namespace")
+        self._kubernetes_adapter = kubernetes_adapter
+        self._max_attempts = 10
+
+    def rename_job(self, base_name):
+        counter = 0
+        while counter < self._max_attempts:
+            trial_job_name = self._tag_job_name_with_uuid(base_name)
+            counter += 1
+            if not self._does_job_exist(trial_job_name):
+                break
+        if counter >= self._max_attempts:
+            raise RuntimeError(f'{counter} attempts to find a unique job name all failed')
+        return trial_job_name
+
+    def _does_job_exist(self, job_name):
+        try:
+            self._kubernetes_adapter.get_namespaced_custom_object(
+                CRD_GROUP,
+                CRD_VERSION,
+                self._namespace,
+                CRD_PLURAL,
+                job_name
+            )
+            return False
+        except ApiException:
+            return True
+
+    @staticmethod
+    def _tag_job_name_with_uuid(base_name):
+        uuid_tag = uuid4()
+        return f'{base_name}-{uuid_tag}'

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
@@ -1,5 +1,6 @@
-from kubernetes.client.rest import ApiException
 import uuid
+
+from kubernetes.client.rest import ApiException
 
 from PiezoWebApp.src.services.spark_job.i_spark_job_namer import ISparkJobNamer
 from PiezoWebApp.src.services.spark_job.spark_job_constants import CRD_GROUP

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
@@ -1,5 +1,5 @@
 from kubernetes.client.rest import ApiException
-from uuid import uuid4
+import uuid
 
 from PiezoWebApp.src.services.spark_job.i_spark_job_namer import ISparkJobNamer
 from PiezoWebApp.src.services.spark_job.spark_job_constants import CRD_GROUP
@@ -39,5 +39,5 @@ class SparkJobNamer(ISparkJobNamer):
 
     @staticmethod
     def _tag_job_name_with_uuid(base_name):
-        uuid_tag = uuid4()
+        uuid_tag = uuid.uuid4()
         return f'{base_name}-{uuid_tag}'

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
@@ -40,9 +40,6 @@ class SparkJobNamer(ISparkJobNamer):
 
     @staticmethod
     def _tag_job_name_with_uuid(base_name):
-        # UUIDs are sequences of 32 hexadecimal digits separated by hyphens
-        # 32 hexadecimal digits have a total number of possible combinations that is over 3.4E38
-        # Here we trim the UUID to just 8 hexadecimal digits
-        # 16 hexadecimal digits have a total number of possible combinations that is over 4.2E9
-        uuid_tag = str(uuid.uuid4())[:8]
+        # https://github.com/ukaea/piezo/wiki/WebAppDecisionRecord#job-uuid-tag-length
+        uuid_tag = str(uuid.uuid4())[:5]
         return f'{base_name}-{uuid_tag}'

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
@@ -34,9 +34,9 @@ class SparkJobNamer(ISparkJobNamer):
                 CRD_PLURAL,
                 job_name
             )
-            return False
-        except ApiException:
             return True
+        except ApiException:
+            return False
 
     @staticmethod
     def _tag_job_name_with_uuid(base_name):

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -64,6 +64,11 @@ class SparkJobService(ISparkJobService):
                 'status': exception.status,
                 'message': message
             }
+        except KeyError as exception:
+            message = f'Unexpected response from Kubernetes API when trying to get status of spark job "{job_name}"' \
+                      f' in namespace "{namespace}": {api_response}'
+            self._logger.error(message)
+            raise exception
 
     def get_logs(self, job_name, namespace):
         try:

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -1,16 +1,10 @@
 from kubernetes.client.rest import ApiException
 
-from PiezoWebApp.src.services.spark_job.i_spark_job_service import ISparkJobService
 from PiezoWebApp.src.models.return_status import StatusCodes
-
-# str | The custom resource's group name
-CRD_GROUP = 'sparkoperator.k8s.io'
-
-# str | The custom resource's plural name. For TPRs this would be lowercase plural kind.
-CRD_PLURAL = 'sparkapplications'
-
-# str | The custom resource's version
-CRD_VERSION = 'v1beta1'
+from PiezoWebApp.src.services.spark_job.i_spark_job_service import ISparkJobService
+from PiezoWebApp.src.services.spark_job.spark_job_constants import CRD_GROUP
+from PiezoWebApp.src.services.spark_job.spark_job_constants import CRD_PLURAL
+from PiezoWebApp.src.services.spark_job.spark_job_constants import CRD_VERSION
 
 
 class SparkJobService(ISparkJobService):
@@ -103,6 +97,9 @@ class SparkJobService(ISparkJobService):
                 'status': StatusCodes.Bad_request.value,
                 'message': validated_body_values.message
             }
+
+        # Make the job name unique
+
 
         # Populate the manifest
         body = self._manifest_populator.build_manifest(validated_body_values.validated_value)

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
@@ -29,7 +29,6 @@ def _validate_name(value):
     if len(value) > 200:
         return ValidationResult(False, '"name" input has a maximum length of 200 characters', None)
 
-    # TODO composed of a-z-. and must start/end with a-z
     return ValidationResult(True, None, value)
 
 

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
@@ -24,8 +24,11 @@ def _validate_name(value):
     validation_result = _validate_non_empty_string("name", value)
     if not validation_result.is_valid:
         return validation_result
+
+    # https://github.com/ukaea/piezo/wiki/WebAppDecisionRecord#maximum-length-of-a-job-name
     if len(value) > 200:
         return ValidationResult(False, '"name" input has a maximum length of 200 characters', None)
+
     # TODO composed of a-z-. and must start/end with a-z
     return ValidationResult(True, None, value)
 

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
@@ -3,6 +3,8 @@ from PiezoWebApp.src.models.spark_job_validation_result import ValidationResult
 
 
 def validate(key, value, validation_rule):
+    if key == "name":
+        return _validate_name(value)
     if key in ["name", "path_to_main_app_file", "main_class", "label"]:
         return _validate_non_empty_string(key, value)
     if key in ["language", "python_version"]:
@@ -16,6 +18,16 @@ def validate(key, value, validation_rule):
     if key in ["arguments"]:
         return ValidationResult(True, None, value)
     raise ValueError(f"Unexpected argument {key}")
+
+
+def _validate_name(value):
+    validation_result = _validate_non_empty_string("name", value)
+    if not validation_result.is_valid:
+        return validation_result
+    if len(value) > 200:
+        return ValidationResult(False, '"name" input has a maximum length of 200 characters', None)
+    # TODO composed of a-z-. and must start/end with a-z
+    return ValidationResult(True, None, value)
 
 
 def _validate_non_empty_string(key, value):

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/base_integration_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/base_integration_test.py
@@ -1,8 +1,9 @@
 from abc import ABCMeta, abstractmethod
 import json
 import logging
-import mock
 import os
+
+import mock
 import pytest
 import tornado.testing
 from tornado.web import Application

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
@@ -51,13 +51,13 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             CRD_VERSION,
             'default',
             CRD_PLURAL,
-            'test_python_job-abcd1234'
+            'test_python_job-abcd1'
         )
         expected_body = {
             'apiVersion': 'sparkoperator.k8s.io/v1beta1',
             'kind': 'SparkApplication',
             'metadata': {
-                'name': 'test_python_job-abcd1234',
+                'name': 'test_python_job-abcd1',
                 'namespace': 'default'
             },
             'spec': {
@@ -119,7 +119,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'status': 'success',
             'data': {
                 'message': 'Job driver created successfully',
-                'job_name': 'test_python_job-abcd1234'
+                'job_name': 'test_python_job-abcd1'
             }
         })
 
@@ -145,13 +145,13 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             CRD_VERSION,
             'default',
             CRD_PLURAL,
-            'test_scala_job-abcd1234'
+            'test_scala_job-abcd1'
         )
         expected_body = {
             'apiVersion': 'sparkoperator.k8s.io/v1beta1',
             'kind': 'SparkApplication',
             'metadata': {
-                'name': 'test_scala_job-abcd1234',
+                'name': 'test_scala_job-abcd1',
                 'namespace': 'default'
             },
             'spec': {
@@ -213,7 +213,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'status': 'success',
             'data': {
                 'message': 'Job driver created successfully',
-                'job_name': 'test_scala_job-abcd1234'
+                'job_name': 'test_scala_job-abcd1'
             }
         })
 
@@ -244,13 +244,13 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             CRD_VERSION,
             'default',
             CRD_PLURAL,
-            'test_python_job-abcd1234'
+            'test_python_job-abcd1'
         )
         expected_body = {
             'apiVersion': 'sparkoperator.k8s.io/v1beta1',
             'kind': 'SparkApplication',
             'metadata': {
-                'name': 'test_python_job-abcd1234',
+                'name': 'test_python_job-abcd1',
                 'namespace': 'default',
                 'labels': {
                     'userLabel': 'my_label'
@@ -314,7 +314,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'status': 'success',
             'data': {
                 'message': 'Job driver created successfully',
-                'job_name': 'test_python_job-abcd1234'
+                'job_name': 'test_python_job-abcd1'
             }
         })
 

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
@@ -40,14 +40,14 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         kubernetes_response = {'metadata': {'name': 'test_python_job'}}
         self.mock_k8s_adapter.create_namespaced_custom_object.return_value = kubernetes_response
         # Act
-        with patch('uuid.uuid4', return_value='abc123'):
+        with patch('uuid.uuid4', return_value='abcd1234-ef56-gh78-ij90'):
             response_body, response_code = yield self.send_request(body)
         # Assert
         expected_body = {
             'apiVersion': 'sparkoperator.k8s.io/v1beta1',
             'kind': 'SparkApplication',
             'metadata': {
-                'name': 'test_python_job-abc123',
+                'name': 'test_python_job-abcd1234',
                 'namespace': 'default'
             },
             'spec': {
@@ -101,7 +101,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'status': 'success',
             'data': {
                 'message': 'Job driver created successfully',
-                'job_name': 'test_python_job-abc123'
+                'job_name': 'test_python_job-abcd1234'
             }
         })
 
@@ -117,14 +117,14 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         kubernetes_response = {'metadata': {'name': 'test_scala_job'}}
         self.mock_k8s_adapter.create_namespaced_custom_object.return_value = kubernetes_response
         # Act
-        with patch('uuid.uuid4', return_value='abc123'):
+        with patch('uuid.uuid4', return_value='abcd1234-ef56-gh78-ij90'):
             response_body, response_code = yield self.send_request(body)
         # Assert
         expected_body = {
             'apiVersion': 'sparkoperator.k8s.io/v1beta1',
             'kind': 'SparkApplication',
             'metadata': {
-                'name': 'test_scala_job-abc123',
+                'name': 'test_scala_job-abcd1234',
                 'namespace': 'default'
             },
             'spec': {
@@ -178,7 +178,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'status': 'success',
             'data': {
                 'message': 'Job driver created successfully',
-                'job_name': 'test_scala_job-abc123'
+                'job_name': 'test_scala_job-abcd1234'
             }
         })
 
@@ -199,14 +199,14 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         kubernetes_response = {'metadata': {'name': 'test_python_job'}}
         self.mock_k8s_adapter.create_namespaced_custom_object.return_value = kubernetes_response
         # Act
-        with patch('uuid.uuid4', return_value='abc123'):
+        with patch('uuid.uuid4', return_value='abcd1234-ef56-gh78-ij90'):
             response_body, response_code = yield self.send_request(body)
         # Assert
         expected_body = {
             'apiVersion': 'sparkoperator.k8s.io/v1beta1',
             'kind': 'SparkApplication',
             'metadata': {
-                'name': 'test_python_job-abc123',
+                'name': 'test_python_job-abcd1234',
                 'namespace': 'default'
             },
             'spec': {
@@ -260,7 +260,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'status': 'success',
             'data': {
                 'message': 'Job driver created successfully',
-                'job_name': 'test_python_job-abc123'
+                'job_name': 'test_python_job-abcd1234'
             }
         })
 

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import json
+from kubernetes.client.rest import ApiException
 import pytest
 from tornado.httpclient import HTTPClientError
 from tornado.testing import gen_test
@@ -38,12 +39,20 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'python_version': '2',
             'arguments': ["1000"]
         }
+        self.mock_k8s_adapter.get_namespaced_custom_object.side_effect = ApiException(status=999)
         kubernetes_response = {'metadata': {'name': 'test_python_job'}}
         self.mock_k8s_adapter.create_namespaced_custom_object.return_value = kubernetes_response
         # Act
         with patch('uuid.uuid4', return_value='abcd1234-ef56-gh78-ij90'):
             response_body, response_code = yield self.send_request(body)
         # Assert
+        self.mock_k8s_adapter.get_namespaced_custom_object.assert_called_once_with(
+            CRD_GROUP,
+            CRD_VERSION,
+            'default',
+            CRD_PLURAL,
+            'test_python_job-abcd1234'
+        )
         expected_body = {
             'apiVersion': 'sparkoperator.k8s.io/v1beta1',
             'kind': 'SparkApplication',
@@ -124,12 +133,20 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'main_class': 'main.class',
             'arguments': ["1000"]
         }
+        self.mock_k8s_adapter.get_namespaced_custom_object.side_effect = ApiException(status=999)
         kubernetes_response = {'metadata': {'name': 'test_scala_job'}}
         self.mock_k8s_adapter.create_namespaced_custom_object.return_value = kubernetes_response
         # Act
         with patch('uuid.uuid4', return_value='abcd1234-ef56-gh78-ij90'):
             response_body, response_code = yield self.send_request(body)
         # Assert
+        self.mock_k8s_adapter.get_namespaced_custom_object.assert_called_once_with(
+            CRD_GROUP,
+            CRD_VERSION,
+            'default',
+            CRD_PLURAL,
+            'test_scala_job-abcd1234'
+        )
         expected_body = {
             'apiVersion': 'sparkoperator.k8s.io/v1beta1',
             'kind': 'SparkApplication',
@@ -215,12 +232,20 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'executor_memory': '4096m',
             'label': 'my_label'
         }
+        self.mock_k8s_adapter.get_namespaced_custom_object.side_effect = ApiException(status=999)
         kubernetes_response = {'metadata': {'name': 'test_python_job'}}
         self.mock_k8s_adapter.create_namespaced_custom_object.return_value = kubernetes_response
         # Act
         with patch('uuid.uuid4', return_value='abcd1234-ef56-gh78-ij90'):
             response_body, response_code = yield self.send_request(body)
         # Assert
+        self.mock_k8s_adapter.get_namespaced_custom_object.assert_called_once_with(
+            CRD_GROUP,
+            CRD_VERSION,
+            'default',
+            CRD_PLURAL,
+            'test_python_job-abcd1234'
+        )
         expected_body = {
             'apiVersion': 'sparkoperator.k8s.io/v1beta1',
             'kind': 'SparkApplication',
@@ -311,7 +336,8 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         with pytest.raises(HTTPClientError) as error:
             yield self.send_request(body)
         # Assert
-        assert self.mock_k8s_adapter.create_namespaced_custom_object.assert_not_called
+        self.mock_k8s_adapter.get_namespaced_custom_object.assert_not_called()
+        self.mock_k8s_adapter.create_namespaced_custom_object.assert_not_called()
         assert error.value.response.code == 400
         msg = json.loads(error.value.response.body, encoding='utf-8')['data']
         assert msg == "The following errors were found:\n" \
@@ -337,7 +363,8 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         with pytest.raises(HTTPClientError) as error:
             yield self.send_request(body)
         # Assert
-        assert self.mock_k8s_adapter.create_namespaced_custom_object.assert_not_called
+        self.mock_k8s_adapter.get_namespaced_custom_object.assert_not_called()
+        self.mock_k8s_adapter.create_namespaced_custom_object.assert_not_called()
         msg = json.loads(error.value.response.body, encoding='utf-8')['data']
         assert error.value.response.code == 400
         assert msg == "The following errors were found:\n" \
@@ -361,7 +388,8 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         with pytest.raises(HTTPClientError) as error:
             yield self.send_request(body)
         # Assert
-        assert self.mock_k8s_adapter.create_namespaced_custom_object.assert_not_called
+        self.mock_k8s_adapter.get_namespaced_custom_object.assert_not_called()
+        self.mock_k8s_adapter.create_namespaced_custom_object.assert_not_called()
         assert error.value.response.code == 400
         msg = json.loads(error.value.response.body, encoding='utf-8')['data']
         assert msg == "The following errors were found:\n" \

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import json
 import pytest
 from tornado.httpclient import HTTPClientError
@@ -38,13 +40,14 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         kubernetes_response = {'metadata': {'name': 'test_python_job'}}
         self.mock_k8s_adapter.create_namespaced_custom_object.return_value = kubernetes_response
         # Act
-        response_body, response_code = yield self.send_request(body)
+        with patch('uuid.uuid4', return_value='abc123'):
+            response_body, response_code = yield self.send_request(body)
         # Assert
         expected_body = {
             'apiVersion': 'sparkoperator.k8s.io/v1beta1',
             'kind': 'SparkApplication',
             'metadata': {
-                'name': 'test_python_job',
+                'name': 'test_python_job-abc123',
                 'namespace': 'default'
             },
             'spec': {
@@ -98,7 +101,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'status': 'success',
             'data': {
                 'message': 'Job driver created successfully',
-                'driver_name': 'test_python_job-driver'
+                'job_name': 'test_python_job-abc123'
             }
         })
 
@@ -114,13 +117,14 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         kubernetes_response = {'metadata': {'name': 'test_scala_job'}}
         self.mock_k8s_adapter.create_namespaced_custom_object.return_value = kubernetes_response
         # Act
-        response_body, response_code = yield self.send_request(body)
+        with patch('uuid.uuid4', return_value='abc123'):
+            response_body, response_code = yield self.send_request(body)
         # Assert
         expected_body = {
             'apiVersion': 'sparkoperator.k8s.io/v1beta1',
             'kind': 'SparkApplication',
             'metadata': {
-                'name': 'test_scala_job',
+                'name': 'test_scala_job-abc123',
                 'namespace': 'default'
             },
             'spec': {
@@ -174,7 +178,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'status': 'success',
             'data': {
                 'message': 'Job driver created successfully',
-                'driver_name': 'test_scala_job-driver'
+                'job_name': 'test_scala_job-abc123'
             }
         })
 
@@ -195,13 +199,14 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         kubernetes_response = {'metadata': {'name': 'test_python_job'}}
         self.mock_k8s_adapter.create_namespaced_custom_object.return_value = kubernetes_response
         # Act
-        response_body, response_code = yield self.send_request(body)
+        with patch('uuid.uuid4', return_value='abc123'):
+            response_body, response_code = yield self.send_request(body)
         # Assert
         expected_body = {
             'apiVersion': 'sparkoperator.k8s.io/v1beta1',
             'kind': 'SparkApplication',
             'metadata': {
-                'name': 'test_python_job',
+                'name': 'test_python_job-abc123',
                 'namespace': 'default'
             },
             'spec': {
@@ -255,7 +260,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'status': 'success',
             'data': {
                 'message': 'Job driver created successfully',
-                'driver_name': 'test_python_job-driver'
+                'job_name': 'test_python_job-abc123'
             }
         })
 

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
@@ -212,7 +212,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'kind': 'SparkApplication',
             'metadata': {
                 'name': 'test_python_job-abcd1234',
-                'namespace': 'default'
+                'namespace': 'default',
                 'labels': {
                     'userLabel': 'my_label'
                 }

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_namer_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_namer_test.py
@@ -20,7 +20,7 @@ class TestSparkJobNamer(TestCase):
 
     def test_rename_job_tags_names_with_uuid(self):
         # Arrange
-        self.mock_kubernetes_adapter.get_namespaced_custom_object.return_value = {'status': 'RUNNING'}
+        self.mock_kubernetes_adapter.get_namespaced_custom_object.side_effect = ApiException(status=999)
         base_name = 'test-job'
         # Act
         job_name = self.test_namer.rename_job(base_name)
@@ -32,8 +32,8 @@ class TestSparkJobNamer(TestCase):
     def test_rename_job_handles_one_coincidental_match(self):
         # Arrange
         self.mock_kubernetes_adapter.get_namespaced_custom_object.side_effect = [
-            ApiException(),
-            {'status': 'RUNNING'}
+            {'status': 'RUNNING'},
+            ApiException(status=999)
         ]
         base_name = 'test-job'
         # Act
@@ -48,7 +48,7 @@ class TestSparkJobNamer(TestCase):
 
     def test_rename_job_raises_if_always_matching(self):
         # Arrange
-        self.mock_kubernetes_adapter.get_namespaced_custom_object.side_effect = ApiException(status=409)
+        self.mock_kubernetes_adapter.get_namespaced_custom_object.return_value = {'status': 'RUNNING'}
         base_name = 'test-job'
         # Act
         with self.assertRaises(RuntimeError, msg='10 attempts to find a unique job name all failed'):

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_namer_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_namer_test.py
@@ -26,7 +26,7 @@ class TestSparkJobNamer(TestCase):
         job_name = self.test_namer.rename_job(base_name)
         # Assert
         self.mock_kubernetes_adapter.get_namespaced_custom_object.assert_called_once()
-        regex = '^' + base_name + '-[0-9a-f]{8}$'
+        regex = '^' + base_name + '-[0-9a-f]{5}$'
         self.assertRegex(job_name, regex)
 
     def test_rename_job_handles_one_coincidental_match(self):
@@ -43,7 +43,7 @@ class TestSparkJobNamer(TestCase):
         assert len(calls) == 2
         assert calls[0][0] == 'get_namespaced_custom_object'
         assert calls[1][0] == 'get_namespaced_custom_object'
-        regex = '^' + base_name + '-[0-9a-f]{8}$'
+        regex = '^' + base_name + '-[0-9a-f]{5}$'
         self.assertRegex(job_name, regex)
 
     def test_rename_job_raises_if_always_matching(self):

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_namer_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_namer_test.py
@@ -26,7 +26,7 @@ class TestSparkJobNamer(TestCase):
         job_name = self.test_namer.rename_job(base_name)
         # Assert
         self.mock_kubernetes_adapter.get_namespaced_custom_object.assert_called_once()
-        regex = '^' + base_name + '-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        regex = '^' + base_name + '-[0-9a-f]{8}$'
         self.assertRegex(job_name, regex)
 
     def test_rename_job_handles_one_coincidental_match(self):
@@ -43,7 +43,7 @@ class TestSparkJobNamer(TestCase):
         assert len(calls) == 2
         assert calls[0][0] == 'get_namespaced_custom_object'
         assert calls[1][0] == 'get_namespaced_custom_object'
-        regex = '^' + base_name + '-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        regex = '^' + base_name + '-[0-9a-f]{8}$'
         self.assertRegex(job_name, regex)
 
     def test_rename_job_raises_if_always_matching(self):

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_namer_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_namer_test.py
@@ -1,0 +1,57 @@
+from unittest import TestCase
+
+from kubernetes.client.rest import ApiException
+import mock
+import pytest
+
+from PiezoWebApp.src.services.kubernetes.i_kubernetes_adapter import IKubernetesAdapter
+from PiezoWebApp.src.services.spark_job.spark_job_namer import SparkJobNamer
+from PiezoWebApp.src.services.spark_job.validation.validation_ruleset import ValidationRuleset
+
+
+class TestSparkJobNamer(TestCase):
+    # pylint: disable=attribute-defined-outside-init
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        mock_validation_ruleset = mock.create_autospec(ValidationRuleset)
+        mock_validation_ruleset.get_default_value_for_key.return_value = "default"
+        self.mock_kubernetes_adapter = mock.create_autospec(IKubernetesAdapter)
+        self.test_namer = SparkJobNamer(self.mock_kubernetes_adapter, mock_validation_ruleset)
+
+    def test_rename_job_tags_names_with_uuid(self):
+        # Arrange
+        self.mock_kubernetes_adapter.get_namespaced_custom_object.return_value = {'status': 'RUNNING'}
+        base_name = 'test-job'
+        # Act
+        job_name = self.test_namer.rename_job(base_name)
+        # Assert
+        self.mock_kubernetes_adapter.get_namespaced_custom_object.assert_called_once()
+        regex = '^' + base_name + '-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        self.assertRegex(job_name, regex)
+
+    def test_rename_job_handles_one_coincidental_match(self):
+        # Arrange
+        self.mock_kubernetes_adapter.get_namespaced_custom_object.side_effect = [
+            ApiException(),
+            {'status': 'RUNNING'}
+        ]
+        base_name = 'test-job'
+        # Act
+        job_name = self.test_namer.rename_job(base_name)
+        # Assert
+        calls = self.mock_kubernetes_adapter.method_calls
+        assert len(calls) == 2
+        assert calls[0][0] == 'get_namespaced_custom_object'
+        assert calls[1][0] == 'get_namespaced_custom_object'
+        regex = '^' + base_name + '-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        self.assertRegex(job_name, regex)
+
+    def test_rename_job_raises_if_always_matching(self):
+        # Arrange
+        self.mock_kubernetes_adapter.get_namespaced_custom_object.side_effect = ApiException(status=409)
+        base_name = 'test-job'
+        # Act
+        with self.assertRaises(RuntimeError, msg='10 attempts to find a unique job name all failed'):
+            self.test_namer.rename_job(base_name)
+        # Assert
+        assert len(self.mock_kubernetes_adapter.method_calls) == 10

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -106,11 +106,11 @@ class TestSparkJobService(TestCase):
         }
         self.mock_validation_service.validate_request_keys.return_value = ValidationResult(True, "", None)
         self.mock_validation_service.validate_request_values.return_value = ValidationResult(True, "", body)
-        self.mock_spark_job_namer.rename_job.return_value = 'test-spark-job-123abc'
+        self.mock_spark_job_namer.rename_job.return_value = 'test-spark-job-abcd1234'
         manifest = {
             'metadata': {
                 'namespace': 'example-namespace',
-                'name': 'test-spark-job-123abc',
+                'name': 'test-spark-job-abcd1234',
                 'language': 'example-language'
             }
         }
@@ -118,7 +118,7 @@ class TestSparkJobService(TestCase):
         self.mock_kubernetes_adapter.create_namespaced_custom_object.return_value = {
             'metadata': {
                 'namespace': 'example-namespace',
-                'name': 'test-spark-job-123abc',
+                'name': 'test-spark-job-abcd1234',
                 'language': 'example-language'
             }
         }
@@ -135,7 +135,7 @@ class TestSparkJobService(TestCase):
         self.assertDictEqual(result, {
             'status': StatusCodes.Okay.value,
             'message': 'Job driver created successfully',
-            'job_name': 'test-spark-job-123abc'
+            'job_name': 'test-spark-job-abcd1234'
         })
 
     def test_submit_job_returns_invalid_body_keys(self):
@@ -179,11 +179,11 @@ class TestSparkJobService(TestCase):
         }
         self.mock_validation_service.validate_request_keys.return_value = ValidationResult(True, "", None)
         self.mock_validation_service.validate_request_values.return_value = ValidationResult(True, "", body)
-        self.mock_spark_job_namer.rename_job.return_value = 'test-spark-job-123abc'
+        self.mock_spark_job_namer.rename_job.return_value = 'test-spark-job-abcd1234'
         manifest = {
             'metadata': {
                 'namespace': 'example-namespace',
-                'name': 'test-spark-job-123abc',
+                'name': 'test-spark-job-abcd1234',
                 'language': 'example-language'
             }
         }
@@ -206,7 +206,7 @@ class TestSparkJobService(TestCase):
             mock.call({
                 'metadata': {
                     'namespace': 'example-namespace',
-                    'name': 'test-spark-job-123abc',
+                    'name': 'test-spark-job-abcd1234',
                     'language': 'example-language'
                 }
             })

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/argument_validator_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/argument_validator_test.py
@@ -14,14 +14,49 @@ def test_validate_name_validates_non_empty_strings(name):
     assert validation_result.is_valid is True
 
 
-@pytest.mark.parametrize("name", ["", "   ", 123])
-def test_validate_name_rejects_empty_strings_and_non_string_values(name):
+@pytest.mark.parametrize("name", ["", "   "])
+def test_validate_name_rejects_empty_strings(name):
     # Arrange
     validation_rule = ValidationRule({'classification': 'Required'})
     # Act
     validation_result = argument_validator.validate("name", name, validation_rule)
     # Assert
     assert validation_result.is_valid is False
+    assert validation_result.message == '"name" input cannot be empty'
+
+
+@pytest.mark.parametrize("name", [123, 3.4])
+def test_validate_name_rejects_non_string_values(name):
+    # Arrange
+    validation_rule = ValidationRule({'classification': 'Required'})
+    # Act
+    validation_result = argument_validator.validate("name", name, validation_rule)
+    # Assert
+    assert validation_result.is_valid is False
+    assert validation_result.message == '"name" input must be a string'
+
+
+def test_validate_name_allows_200_character_name():
+    # Arrange
+    validation_rule = ValidationRule({'classification': 'Required'})
+    name = 'abcdefghijklmnopqrstuvwxy' * 8
+    assert len(name) == 200
+    # Act
+    validation_result = argument_validator.validate("name", name, validation_rule)
+    # Assert
+    assert validation_result.is_valid is True
+
+
+def test_validate_name_rejects_201_character_name():
+    # Arrange
+    validation_rule = ValidationRule({'classification': 'Required'})
+    name = ('abcdefghijklmnopqrstuvwxy' * 8) + 'z'
+    assert len(name) == 201
+    # Act
+    validation_result = argument_validator.validate("name", name, validation_rule)
+    # Assert
+    assert validation_result.is_valid is False
+    assert validation_result.message == '"name" input has a maximum length of 200 characters'
 
 
 @pytest.mark.parametrize("language", ["Python", "Scala"])

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/argument_validator_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/argument_validator_test.py
@@ -202,7 +202,7 @@ def test_validate_driver_memory_accepts_values_for_megabytes_as_string(memory):
         'default': '512m',
         'minimum': 512,
         'maximum': 2048
-      })
+    })
     # Act
     validation_result = argument_validator.validate("driver_memory", memory, validation_rule)
     # Assert

--- a/piezo_web_app/requirements.txt
+++ b/piezo_web_app/requirements.txt
@@ -10,4 +10,5 @@ pytest-tornado
 requests
 tornado
 tornado-json
+uuid
 wheel


### PR DESCRIPTION
Unique ID tag is appended to job names before submission to the Spark Operator. The submit job handler returns this new job name, which must be used (e.g. in get logs or delete job) instead of the submitted job name.

A 200-character limit is applied to the submitted job name (see [decision record](https://github.com/ukaea/piezo/wiki/WebAppDecisionRecord)).

A separate [task](https://github.com/ukaea/piezo/issues/70) has been created for checking the formatting of a submitted job name.

Unit/integration/tests written for this PR.