### PR TITLE
Bug fix/reduce character limit in name to 57/#51

### DIFF
--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -59,12 +59,9 @@ Submit Job With 57 Character Name Runs Successfully
 
 Submit Job With 58 Character Name Fails
     ${response}=    Submit SparkPi Job    abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefgh
-    Confirm Ok Response  ${response}
-    ${job_name}=    Get Response Job Name   ${response}
-    Sleep   5 seconds
-    ${response}=    Get Status Of Spark Job   ${job_name}
-    ${message}=  Get Response Data Message     ${response}
-    Should Be Equal As Strings   ${message}   FAILED
+    Confirm Bad Input Response  ${response}
+    ${error}=   Get Response Data     ${response}
+    Should Be Equal As Strings    ${error}    The following errors were found:\n\"name\" input has a maximum length of 57 characters\n
 
 Submit GroupByTest Spark Job With Arguments Returns Ok Response
     ${response}=    Submit SparkGroupByTest Job With Arguments   spark-group-by-test

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -50,11 +50,21 @@ Submit Two Jobs With Same Name Returns Ok Responses
     Confirm Ok Response  ${response1}
     Confirm Ok Response  ${response2}
 
-Submit Job With 200 Character Name Runs Successfully
-    ${response}=    Submit SparkPi Job    abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy
+Submit Job With 57 Character Name Runs Successfully
+    ${response}=    Submit SparkPi Job    abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefg
     Confirm Ok Response  ${response}
+    ${job_name}=    Get Response Job Name   ${response}
     ${finished}=    Wait For Spark Job To Finish        ${job_name}     5 seconds
     Should Be True      ${finished}
+
+Submit Job With 58 Character Name Fails
+    ${response}=    Submit SparkPi Job    abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefgh
+    Confirm Ok Response  ${response}
+    ${job_name}=    Get Response Job Name   ${response}
+    Sleep   5 seconds
+    ${response}=    Get Status Of Spark Job   ${job_name}
+    ${message}=  Get Response Data Message     ${response}
+    Should Be Equal As Strings   ${message}   FAILED
 
 Submit GroupByTest Spark Job With Arguments Returns Ok Response
     ${response}=    Submit SparkGroupByTest Job With Arguments   spark-group-by-test

--- a/SystemTests/roles/robot/files/requests_helpers.robot
+++ b/SystemTests/roles/robot/files/requests_helpers.robot
@@ -12,6 +12,10 @@ Confirm Not Found Response
   [Arguments]   ${response}
   Should Be Equal As Strings    ${response.status_code}   404
 
+Confirm Bad Input Response
+  [Arguments]   ${response}
+  Should Be Equal As Strings    ${response.status_code}   400
+
 Confirm Ok Response
   [Arguments]   ${response}
   Should Be Equal As Strings    ${response.status_code}   200

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
@@ -27,7 +27,7 @@ def _validate_name(value):
 
     # https://github.com/ukaea/piezo/wiki/WebAppDecisionRecord#maximum-length-of-a-job-name
     if len(value) > 57:
-        return ValidationResult(False, '"name" input has a maximum length of 200 characters', None)
+        return ValidationResult(False, '"name" input has a maximum length of 57 characters', None)
 
     return ValidationResult(True, None, value)
 

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
@@ -26,7 +26,7 @@ def _validate_name(value):
         return validation_result
 
     # https://github.com/ukaea/piezo/wiki/WebAppDecisionRecord#maximum-length-of-a-job-name
-    if len(value) > 200:
+    if len(value) > 57:
         return ValidationResult(False, '"name" input has a maximum length of 200 characters', None)
 
     return ValidationResult(True, None, value)

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/argument_validator_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/argument_validator_test.py
@@ -36,27 +36,27 @@ def test_validate_name_rejects_non_string_values(name):
     assert validation_result.message == '"name" input must be a string'
 
 
-def test_validate_name_allows_200_character_name():
+def test_validate_name_allows_57_character_name():
     # Arrange
     validation_rule = ValidationRule({'classification': 'Required'})
-    name = 'abcdefghijklmnopqrstuvwxy' * 8
-    assert len(name) == 200
+    name = 'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefg'
+    assert len(name) == 57
     # Act
     validation_result = argument_validator.validate("name", name, validation_rule)
     # Assert
     assert validation_result.is_valid is True
 
 
-def test_validate_name_rejects_201_character_name():
+def test_validate_name_rejects_58_character_name():
     # Arrange
     validation_rule = ValidationRule({'classification': 'Required'})
-    name = ('abcdefghijklmnopqrstuvwxy' * 8) + 'z'
-    assert len(name) == 201
+    name = 'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefg' + 'z'
+    assert len(name) == 58
     # Act
     validation_result = argument_validator.validate("name", name, validation_rule)
     # Assert
     assert validation_result.is_valid is False
-    assert validation_result.message == '"name" input has a maximum length of 200 characters'
+    assert validation_result.message == '"name" input has a maximum length of 57 characters'
 
 
 @pytest.mark.parametrize("language", ["Python", "Scala"])


### PR DESCRIPTION
Reduce character limit to 57 characters to match that supported by the spark operator

## To test:
* System tests