### PR TITLE
Feature/user can get names of all spark jobs/#63

### DIFF
--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -34,6 +34,10 @@ Get Logs For Spark Job
     ${response}=  Get Request With Json Body   /piezo/getlogs    ${body}
     [return]    ${response}
 
+Get List Of Spark Jobs
+    ${response}=    Get Request From Route    /piezo/getjobs
+    [return]    ${response}
+
 Get Request From Route
     [Arguments]   ${route}
     Create Session    k8s   ${K8S_ENDPOINT}

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -149,3 +149,21 @@ Job Can Use Data And Code On S3 And Write Back Results
     Directory Should Exist In S3 Bucket   kubernetes    outputs/${job_name}
     Directory Should Not Be Empty In S3 bucket  kubernetes    outputs/${job_name}
     File Should Exist In S3 Bucket    kubernetes      outputs/${job_name}/_SUCCESS
+
+Get List Of SparkApplications Includes Submitted Jobs
+    ${response1}=   Submit SparkPi Job    job1
+    ${response2}=   Submit SparkPi Job    job2
+    ${response3}=   Submit SparkPi Job    job3
+    Confirm Ok Response  ${response1}
+    Confirm Ok Response  ${response2}
+    Confirm Ok Response  ${response3}
+    ${job_name_1}=    Get Response Job Name   ${response1}
+    ${job_name_2}=    Get Response Job Name   ${response2}
+    ${job_name_3}=    Get Response Job Name   ${response3}
+    Sleep     5 seconds
+    ${request_response}=    Get List Of Spark Jobs
+    Confirm Ok Response     ${request_response}
+    ${jobs}=    Get Response data     ${request_response}
+    Dictionary Should Contain Key   ${jobs}   ${job_name_1}
+    Dictionary Should Contain Key   ${jobs}   ${job_name_2}
+    Dictionary Should Contain Key   ${jobs}   ${job_name_3}

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -163,7 +163,7 @@ Get List Of SparkApplications Includes Submitted Jobs
     Sleep     5 seconds
     ${request_response}=    Get List Of Spark Jobs
     Confirm Ok Response     ${request_response}
-    ${jobs}=    Get Response data     ${request_response}
+    ${jobs}=    Get Response Spark Jobs     ${request_response}
     Dictionary Should Contain Key   ${jobs}   ${job_name_1}
     Dictionary Should Contain Key   ${jobs}   ${job_name_2}
     Dictionary Should Contain Key   ${jobs}   ${job_name_3}

--- a/SystemTests/roles/robot/files/requests_helpers.robot
+++ b/SystemTests/roles/robot/files/requests_helpers.robot
@@ -28,6 +28,10 @@ Get Response Data Message
   [Arguments]   ${response}
   [return]    ${response.json()["data"]["message"]}
 
+Get Response Spark Jobs
+  [Arguments]   ${response}
+  [return]    ${response.json()["data"]["spark_jobs"]}
+
 Get Response Job Name
   [Arguments]   ${response}
   [return]    ${response.json()["data"]["job_name"]}

--- a/piezo_web_app/PiezoWebApp/run_piezo.py
+++ b/piezo_web_app/PiezoWebApp/run_piezo.py
@@ -5,6 +5,7 @@ import kubernetes
 import tornado
 
 from PiezoWebApp.src.handlers.delete_job import DeleteJobHandler
+from PiezoWebApp.src.handlers.get_jobs import GetJobsHandler
 from PiezoWebApp.src.handlers.get_logs import GetLogsHandler
 from PiezoWebApp.src.handlers.heartbeat_handler import HeartbeatHandler
 from PiezoWebApp.src.handlers.submit_job import SubmitJobHandler
@@ -71,6 +72,7 @@ def build_app(container, use_route_stem=False):
         [
             (heartbeat_route, HeartbeatHandler),
             (format_route_specification(route_stem + 'deletejob'), DeleteJobHandler, container),
+            (format_route_specification(route_stem + 'getjobs'), GetJobsHandler, container),
             (format_route_specification(route_stem + 'getlogs'), GetLogsHandler, container),
             (format_route_specification(route_stem + 'jobstatus'), JobStatusHandler, container),
             (format_route_specification(route_stem + 'submitjob'), SubmitJobHandler, container)

--- a/piezo_web_app/PiezoWebApp/src/handlers/get_jobs.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/get_jobs.py
@@ -1,8 +1,18 @@
+from tornado_json import schema
+
 from PiezoWebApp.src.handlers.base_handler import BaseHandler
 
 
 # pylint: disable=abstract-method
 class GetJobsHandler(BaseHandler):
+    @schema.validate(
+        output_schema={
+            "type": "object",
+            "properties": {
+                "message": {"type": "string"},
+            },
+        }
+    )
     def get(self, *args, **kwargs):
         result = self._spark_job_service.get_jobs()
         self._logger.debug(f'Getting list of spark applications present returned: "{result}"')

--- a/piezo_web_app/PiezoWebApp/src/handlers/get_jobs.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/get_jobs.py
@@ -10,6 +10,13 @@ class GetJobsHandler(BaseHandler):
             "type": "object",
             "properties": {
                 "message": {"type": "string"},
+                "spark_jobs": {
+                    "type": "object",
+                    "properties": {
+                        "job_name": {"type": "string"},
+                        "status": {"type": "string"}
+                    }
+                }
             },
         }
     )

--- a/piezo_web_app/PiezoWebApp/src/handlers/get_jobs.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/get_jobs.py
@@ -2,7 +2,7 @@ from PiezoWebApp.src.handlers.base_handler import BaseHandler
 
 
 # pylint: disable=abstract-method
-class JobStatusHandler(BaseHandler):
+class GetJobsHandler(BaseHandler):
     def get(self, *args, **kwargs):
         result = self._spark_job_service.get_jobs()
         self._logger.debug(f'Getting list of spark applications present returned: "{result}"')

--- a/piezo_web_app/PiezoWebApp/src/handlers/get_jobs.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/get_jobs.py
@@ -15,7 +15,7 @@ class GetJobsHandler(BaseHandler):
     )
     def get(self, *args, **kwargs):
         result = self._spark_job_service.get_jobs()
-        self._logger.debug(f'Getting list of spark applications present returned: "{result}"')
+        self._logger.debug(f'Getting list of spark applications present returned: "{result["status"]}".')
         self.check_request_was_completed_successfully(result)
         del result['status']
         return result

--- a/piezo_web_app/PiezoWebApp/src/handlers/get_jobs.y.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/get_jobs.y.py
@@ -1,0 +1,11 @@
+from PiezoWebApp.src.handlers.base_handler import BaseHandler
+
+
+# pylint: disable=abstract-method
+class JobStatusHandler(BaseHandler):
+    def get(self, *args, **kwargs):
+        result = self._spark_job_service.get_jobs()
+        self._logger.debug(f'Getting list of spark applications present returned: "{result}"')
+        self.check_request_was_completed_successfully(result)
+        del result['status']
+        return result

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
@@ -32,3 +32,7 @@ class IKubernetesAdapter(metaclass=ABCMeta):
     @abstractmethod
     def get_namespaced_custom_object(self, group, version, namespace, plural, name):
         pass
+
+    @abstractmethod
+    def list_namespaced_custom_object(self, group, version, namespace, plural):
+        pass

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
@@ -41,4 +41,4 @@ class KubernetesAdapter(IKubernetesAdapter):
         return self._custom_connection.get_namespaced_custom_object(group, version, namespace, plural, name)
 
     def list_namespaced_custom_object(self, group, version, namespace, plural):
-        return  self._custom_connection.list_namespaced_custom_object(group, version, namespace, plural)
+        return self._custom_connection.list_namespaced_custom_object(group, version, namespace, plural)

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
@@ -39,3 +39,6 @@ class KubernetesAdapter(IKubernetesAdapter):
 
     def get_namespaced_custom_object(self, group, version, namespace, plural, name):
         return self._custom_connection.get_namespaced_custom_object(group, version, namespace, plural, name)
+
+    def list_namespaced_custom_object(self, group, version, namespace, plural):
+        return  self._custom_connection.list_namespaced_custom_object(group, version, namespace, plural)

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
@@ -8,6 +8,10 @@ class ISparkJobService(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def get_jobs(self):
+        pass
+
+    @abstractmethod
     def get_job_status(self, job_name, namespace):
         pass
 

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -72,7 +72,7 @@ class SparkJobService(ISparkJobService):
 
     def get_jobs(self):
         try:
-            api_response = self._connection.list_namespaced_custom_object(
+            api_response = self._kubernetes_adapter.list_namespaced_custom_object(
                 CRD_GROUP,
                 CRD_VERSION,
                 'default',

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -87,7 +87,7 @@ class SparkJobService(ISparkJobService):
                 'status': StatusCodes.Okay.value
             }
         except ApiException as exception:
-            message = f'Kubernetes error when trying to get a list of current jobs: {exception.reason}'
+            message = f'Kubernetes error when trying to get a list of current spark jobs: {exception.reason}'
             self._logger.error(message)
             return {
                 'status': exception.status,

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -94,8 +94,8 @@ class SparkJobService(ISparkJobService):
                 'message': message
             }
         except KeyError as exception:
-            message = f'Unexpected response from Kubernetes API when trying to get status of spark job "{job_name}"' \
-                      f' in namespace "{namespace}": {api_response}'
+            message = f'Unexpected response from Kubernetes API when trying to get list of spark jobs' \
+                      f' : {api_response}'
             self._logger.error(message)
             raise exception
 

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -93,6 +93,11 @@ class SparkJobService(ISparkJobService):
                 'status': exception.status,
                 'message': message
             }
+        except KeyError as exception:
+            message = f'Unexpected response from Kubernetes API when trying to get status of spark job "{job_name}"' \
+                      f' in namespace "{namespace}": {api_response}'
+            self._logger.error(message)
+            raise exception
 
     def get_logs(self, job_name, namespace):
         try:

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -79,7 +79,7 @@ class SparkJobService(ISparkJobService):
                 CRD_PLURAL
             )
             spark_jobs = {
-                item['metadata']['name']: item['status']['applicationState']['state'] for item in api_response['items']
+                item['metadata']['name']: SparkJobService._retrieve_status(item) for item in api_response['items']
             }
             return {
                 'message': f"Found {len(spark_jobs)} spark jobs",
@@ -165,3 +165,10 @@ class SparkJobService(ISparkJobService):
                 'status': exception.status,
                 'message': message
             }
+
+    @staticmethod
+    def _retrieve_status(item):
+        try:
+            return item['status']['applicationState']['state']
+        except KeyError:
+            return 'UNKNOWN'

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -70,6 +70,29 @@ class SparkJobService(ISparkJobService):
                 'message': message
             }
 
+    def get_jobs(self):
+        try:
+            api_response = self._connection.list_namespaced_custom_object(
+                CRD_GROUP,
+                CRD_VERSION,
+                'default',
+                CRD_PLURAL,
+            )
+            items = api_response['items']
+            names = [item['metadata']['name'] for item in items]
+            return {
+                'message': f"The following sparkapplications were found: {names}",
+                'status': StatusCodes.Okay.value
+            }
+        except ApiException as exception:
+            message = f'Kubernetes error when trying to get a list of current spark applications: {exception.reason}'
+            self._logger.error(message)
+            return {
+                'status': exception.status,
+                'messsage': message
+            }
+
+
     def get_logs(self, job_name, namespace):
         try:
             driver_name = job_name + "-driver"

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -87,7 +87,7 @@ class SparkJobService(ISparkJobService):
                 'status': StatusCodes.Okay.value
             }
         except ApiException as exception:
-            message = f'Kubernetes error when trying to get a list of current spark jobs: {exception.reason}'
+            message = f'Kubernetes error when trying to get a list of current jobs: {exception.reason}'
             self._logger.error(message)
             return {
                 'status': exception.status,

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -89,7 +89,7 @@ class SparkJobService(ISparkJobService):
             self._logger.error(message)
             return {
                 'status': exception.status,
-                'messsage': message
+                'message': message
             }
 
 

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -81,7 +81,7 @@ class SparkJobService(ISparkJobService):
             items = api_response['items']
             names = [item['metadata']['name'] for item in items]
             return {
-                'message': f"The following sparkapplications were found: {names}",
+                'message': f"The following spark applications were found: {names}",
                 'status': StatusCodes.Okay.value
             }
         except ApiException as exception:

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -76,21 +76,18 @@ class SparkJobService(ISparkJobService):
                 CRD_GROUP,
                 CRD_VERSION,
                 'default',
-                CRD_PLURAL,
+                CRD_PLURAL
             )
-            spark_applications = {}
-            items = api_response['items']
-            for item in items:
-                name = item['metadata']['name']
-                status = item['status']['applicationState']['state']
-                spark_applications[name] = status
-
+            spark_jobs = {
+                item['metadata']['name']: item['status']['applicationState']['state'] for item in api_response['items']
+            }
             return {
-                'message': f"The following spark applications were found: {spark_applications}",
+                'message': f"Found {len(spark_jobs)} spark jobs",
+                'spark_jobs': spark_jobs,
                 'status': StatusCodes.Okay.value
             }
         except ApiException as exception:
-            message = f'Kubernetes error when trying to get a list of current spark applications: {exception.reason}'
+            message = f'Kubernetes error when trying to get a list of current spark jobs: {exception.reason}'
             self._logger.error(message)
             return {
                 'status': exception.status,

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -78,10 +78,15 @@ class SparkJobService(ISparkJobService):
                 'default',
                 CRD_PLURAL,
             )
+            spark_applications = {}
             items = api_response['items']
-            names = [item['metadata']['name'] for item in items]
+            for item in items:
+                name = item['metadata']['name']
+                status = item['status']['applicationState']['state']
+                spark_applications[name] = status
+
             return {
-                'message': f"The following spark applications were found: {names}",
+                'message': f"The following spark applications were found: {spark_applications}",
                 'status': StatusCodes.Okay.value
             }
         except ApiException as exception:

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -92,7 +92,6 @@ class SparkJobService(ISparkJobService):
                 'message': message
             }
 
-
     def get_logs(self, job_name, namespace):
         try:
             driver_name = job_name + "-driver"

--- a/piezo_web_app/PiezoWebApp/tests/handlers/get_jobs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/get_jobs_test.py
@@ -1,0 +1,61 @@
+from mock import call
+from tornado.testing import gen_test
+
+from PiezoWebApp.tests.handlers.base_handler_test import BaseHandlerTest
+from PiezoWebApp.src.handlers.get_jobs import GetJobsHandler
+
+
+class TestGetLogsHandler(BaseHandlerTest):
+    @property
+    def handler(self):
+        return GetJobsHandler
+
+    @property
+    def standard_request_method(self):
+        return 'GET'
+
+    @gen_test
+    def test_get_returns_array_of_jobs_when_successful(self):
+        # Arrange
+        self.mock_spark_job_service.get_jobs.return_value = {
+            "message": "The following spark applications were found: [job1, job2, job3]",
+            "status": 200
+        }
+        body = None
+        # Act
+        response_body, response_code = yield self.send_request(body)
+        # Assert
+        self.mock_spark_job_service.get_jobs.assert_called_once()
+        self.mock_logger.debug.assert_has_calls([
+            call('Getting list of spark applications present returned: "200".')
+        ])
+        assert response_code == 200
+        self.assertDictEqual(response_body, {
+            'status': 'success',
+            'data': {
+                'message': "The following spark applications were found: [job1, job2, job3]"
+            }
+        })
+
+    @gen_test
+    def test_get_returns_empty_array_when_no_jobs_present(self):
+        # Arrange
+        self.mock_spark_job_service.get_jobs.return_value = {
+            "message": "The following spark applications were found: []",
+            "status": 200
+        }
+        body = None
+        # Act
+        response_body, response_code = yield self.send_request(body)
+        # Assert
+        self.mock_spark_job_service.get_jobs.assert_called_once()
+        self.mock_logger.debug.assert_has_calls([
+            call('Getting list of spark applications present returned: "200".')
+        ])
+        assert response_code == 200
+        self.assertDictEqual(response_body, {
+            'status': 'success',
+            'data': {
+                'message': "The following spark applications were found: []"
+            }
+        })

--- a/piezo_web_app/PiezoWebApp/tests/handlers/get_jobs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/get_jobs_test.py
@@ -18,7 +18,8 @@ class TestGetLogsHandler(BaseHandlerTest):
     def test_get_returns_array_of_jobs_when_successful(self):
         # Arrange
         self.mock_spark_job_service.get_jobs.return_value = {
-            "message": "The following spark applications were found: [job1, job2, job3]",
+            "message": "Found 3 spark jobs",
+            "spark_jobs": {"job_1": "COMPLETED", "job_2": "RUNNING", "job_3": "PENDING"},
             "status": 200
         }
         body = None
@@ -33,7 +34,8 @@ class TestGetLogsHandler(BaseHandlerTest):
         self.assertDictEqual(response_body, {
             'status': 'success',
             'data': {
-                'message': "The following spark applications were found: [job1, job2, job3]"
+                'message': "Found 3 spark jobs",
+                'spark_jobs': {'job_1': "COMPLETED", "job_2": "RUNNING", "job_3": "PENDING"}
             }
         })
 
@@ -41,7 +43,8 @@ class TestGetLogsHandler(BaseHandlerTest):
     def test_get_returns_empty_array_when_no_jobs_present(self):
         # Arrange
         self.mock_spark_job_service.get_jobs.return_value = {
-            "message": "The following spark applications were found: []",
+            "message": "Found 0 spark jobs",
+            "spark_jobs": {},
             "status": 200
         }
         body = None
@@ -56,6 +59,7 @@ class TestGetLogsHandler(BaseHandlerTest):
         self.assertDictEqual(response_body, {
             'status': 'success',
             'data': {
-                'message': "The following spark applications were found: []"
+                'message': "Found 0 spark jobs",
+                'spark_jobs': {}
             }
         })

--- a/piezo_web_app/PiezoWebApp/tests/handlers/get_jobs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/get_jobs_test.py
@@ -5,7 +5,7 @@ from PiezoWebApp.tests.handlers.base_handler_test import BaseHandlerTest
 from PiezoWebApp.src.handlers.get_jobs import GetJobsHandler
 
 
-class TestGetLogsHandler(BaseHandlerTest):
+class TestGetJobsHandler(BaseHandlerTest):
     @property
     def handler(self):
         return GetJobsHandler

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/get_jobs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/get_jobs_test.py
@@ -1,8 +1,4 @@
-import json
-import pytest
-from tornado.httpclient import HTTPClientError
 from tornado.testing import gen_test
-from kubernetes.client.rest import ApiException
 
 from PiezoWebApp.src.handlers.get_jobs import GetJobsHandler
 from PiezoWebApp.tests.integration_tests.base_integration_test import BaseIntegrationTest

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/get_jobs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/get_jobs_test.py
@@ -27,7 +27,22 @@ class TestGetJobsIntegration(BaseIntegrationTest):
     def test_list_of_current_jobs_is_returned_as_array(self):
         # Arrange
         body = None
-        kubernetes_response = {"items": [{"metadata": {"name": "job1"}}, {"metadata": {"name": "job2"}}]}
+        kubernetes_response = {"items": [
+            {
+                "metadata":
+                    {"name": "job1"},
+                "status":
+                    {"applicationState":
+                         {"state": "RUNNING"}}
+            },
+            {
+                "metadata":
+                    {"name": "job2"},
+                "status":
+                    {"applicationState":
+                         {"state": "COMPLETED"}}
+            }
+        ]}
         self.mock_k8s_adapter.list_namespaced_custom_object.return_value = kubernetes_response
         # Act
         response_body, response_code = yield self.send_request(body)
@@ -41,6 +56,7 @@ class TestGetJobsIntegration(BaseIntegrationTest):
         self.assertDictEqual(response_body, {
             'status': 'success',
             'data': {
-                "message": "The following spark applications were found: ['job1', 'job2']"
+                "message": "Found 2 spark jobs",
+                "spark_jobs": {"job1": "RUNNING", "job2": "COMPLETED"}
             }
         })

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/get_jobs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/get_jobs_test.py
@@ -30,17 +30,29 @@ class TestGetJobsIntegration(BaseIntegrationTest):
         kubernetes_response = {"items": [
             {
                 "metadata":
-                    {"name": "job1"},
+                    {
+                        "name": "job1"
+                    },
                 "status":
-                    {"applicationState":
-                         {"state": "RUNNING"}}
+                    {
+                        "applicationState":
+                            {
+                                "state": "RUNNING"
+                            }
+                    }
             },
             {
                 "metadata":
-                    {"name": "job2"},
+                    {
+                        "name": "job2"
+                    },
                 "status":
-                    {"applicationState":
-                         {"state": "COMPLETED"}}
+                    {
+                        "applicationState":
+                            {
+                                "state": "COMPLETED"
+                            }
+                    }
             }
         ]}
         self.mock_k8s_adapter.list_namespaced_custom_object.return_value = kubernetes_response

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/get_jobs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/get_jobs_test.py
@@ -1,0 +1,50 @@
+import json
+import pytest
+from tornado.httpclient import HTTPClientError
+from tornado.testing import gen_test
+from kubernetes.client.rest import ApiException
+
+from PiezoWebApp.src.handlers.get_jobs import GetJobsHandler
+from PiezoWebApp.tests.integration_tests.base_integration_test import BaseIntegrationTest
+
+
+# str | The custom resource's group name
+CRD_GROUP = 'sparkoperator.k8s.io'
+
+# str | The custom resource's plural name. For TPRs this would be lowercase plural kind.
+CRD_PLURAL = 'sparkapplications'
+
+# str | The custom resource's version
+CRD_VERSION = 'v1beta1'
+
+
+class TestGetJobsIntegration(BaseIntegrationTest):
+    @property
+    def handler(self):
+        return GetJobsHandler
+
+    @property
+    def standard_request_method(self):
+        return 'GET'
+
+    @gen_test
+    def test_list_of_current_jobs_is_returned_as_array(self):
+        # Arrange
+        body = None
+        kubernetes_response = {"items": [{"metadata": {"name": "job1"}}, {"metadata": {"name": "job2"}}]}
+        self.mock_k8s_adapter.list_namespaced_custom_object.return_value = kubernetes_response
+        # Act
+        response_body, response_code = yield self.send_request(body)
+        # Assert
+        assert self.mock_k8s_adapter.list_namespaced_custom_object.call_count == 1
+        self.mock_k8s_adapter.list_namespaced_custom_object.assert_called_once_with(CRD_GROUP,
+                                                                                    CRD_VERSION,
+                                                                                    'default',
+                                                                                    CRD_PLURAL)
+        assert response_code == 200
+        self.assertDictEqual(response_body, {
+            'status': 'success',
+            'data': {
+                "message": "The following spark applications were found: ['job1', 'job2']"
+            }
+        })

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -275,3 +275,19 @@ class TestSparkJobService(TestCase):
             'message': 'Kubernetes error when trying to get status of spark job "test-job" in namespace'
                        ' "test-namespace": Reason'
         })
+
+    def test_retrieve_job_status_returns_status_if_present(self):
+        # Arrange
+        item = {"status": {"applicationState": {"state": "RUNNING"}}}
+        # Act
+        status = self.test_service._retrieve_status(item)
+        # Assert
+        assert status == "RUNNING"
+
+    def test_retrieve_job_status_returns_UNKNOWN_if_status_is_missing(self):
+        # Arrange
+        item = {"some_keys": "some_values"}
+        # Act
+        status = self.test_service._retrieve_status(item)
+        # Assert
+        assert status == "UNKNOWN"

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -70,6 +70,31 @@ class TestSparkJobService(TestCase):
         assert result['status'] == 999
         assert result['message'] == expected_message
 
+    def test_get_jobs_sends_expected_arguments(self):
+        # Arrange
+        self.mock_kubernetes_adapter.list_namespaced_custom_object.return_value = {"items": []}
+        # Act
+        result = self.test_service.get_jobs()
+        # Assert
+        self.assertDictEqual(result, {'message': 'The following spark applications were found: []', 'status': 200})
+        self.mock_kubernetes_adapter.list_namespaced_custom_object.assert_called_once_with(
+            CRD_GROUP, CRD_VERSION, 'default', CRD_PLURAL)
+
+    def test_get_jobs_logs_and_returns_api_exception_reason(self):
+        # Arrange
+        self.mock_kubernetes_adapter.list_namespaced_custom_object.side_effect = \
+            ApiException(reason="Reason", status=999)
+        # Act
+        result = self.test_service.get_jobs()
+        # Assert
+        expected_message = \
+            'Kubernetes error when trying to get a list of current spark applications: Reason'
+        self.mock_logger.error.assert_called_once_with(expected_message)
+        self.assertDictEqual(result, {
+            'status': 999,
+            'message': 'Kubernetes error when trying to get a list of current spark applications: Reason'
+        })
+
     def test_get_logs_sends_expected_arguments(self):
         # Arrange
         self.mock_kubernetes_adapter.read_namespaced_pod_log.return_value = "Response"

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -76,7 +76,7 @@ class TestSparkJobService(TestCase):
         # Act
         result = self.test_service.get_jobs()
         # Assert
-        self.assertDictEqual(result, {'message': 'The following spark applications were found: []', 'status': 200})
+        self.assertDictEqual(result, {'message': 'Found 0 spark jobs', 'spark_jobs': {}, 'status': 200})
         self.mock_kubernetes_adapter.list_namespaced_custom_object.assert_called_once_with(
             CRD_GROUP, CRD_VERSION, 'default', CRD_PLURAL)
 
@@ -88,11 +88,11 @@ class TestSparkJobService(TestCase):
         result = self.test_service.get_jobs()
         # Assert
         expected_message = \
-            'Kubernetes error when trying to get a list of current spark applications: Reason'
+            'Kubernetes error when trying to get a list of current spark jobs: Reason'
         self.mock_logger.error.assert_called_once_with(expected_message)
         self.assertDictEqual(result, {
             'status': 999,
-            'message': 'Kubernetes error when trying to get a list of current spark applications: Reason'
+            'message': 'Kubernetes error when trying to get a list of current spark jobs: Reason'
         })
 
     def test_get_logs_sends_expected_arguments(self):


### PR DESCRIPTION
New `getjobs` handler that returns a list of spark applications with their status. To be addressed in a later pull request will be the ability to filter by a label see #64 

## Stories covered:
#63 

## To test
Run system tests
