### PR TITLE
Bugfix/catch key errors on job status/#79

### DIFF
--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -138,6 +138,15 @@ Can Get Status Of Submitted Spark Job
     ${response}=  Get Status Of Spark Job   ${job_name}
     Confirm Ok Response     ${response}
 
+Status Of Job Immediately After Submission is Unknown
+    ${job_name}=     Set Variable       spark-pi
+    ${response}=    Submit SparkPi Job    ${job_name}
+    ${job_name}=    Get Response Job Name   ${response}
+    ${response}=  Get Status Of Spark Job   ${job_name}
+    Confirm Ok Response     ${response}
+    ${status}=    Get Response Data Message   ${response}
+    Should Be Equal As Strings    ${status}   UNKNOWN
+
 Job Can Use Data And Code On S3 And Write Back Results
     ${job_name}=    Set Variable      wordcount
     Directory Should Not Exist In S3 Bucket   kubernetes    outputs/${job_name}

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -51,7 +51,7 @@ class SparkJobService(ISparkJobService):
                 CRD_PLURAL,
                 job_name
             )
-            job_status = api_response['status']['applicationState']['state']
+            job_status = SparkJobService._retrieve_status(api_response)
             return {
                 'message': job_status,
                 'status': StatusCodes.Okay.value

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -287,6 +287,21 @@ class TestSparkJobService(TestCase):
             'test-job'
         )
 
+    def test_get_job_status_returns_status_of_job_as_unknown_when_missing(self):
+        # Arrange
+        self.mock_kubernetes_adapter.get_namespaced_custom_object.return_value = {'name': 'test-job'}
+        # Act
+        result = self.test_service.get_job_status('test-job', 'test-namespace')
+        # Assert
+        self.assertDictEqual(result, {'message': 'UNKNOWN', 'status': 200})
+        self.mock_kubernetes_adapter.get_namespaced_custom_object.assert_called_once_with(
+            CRD_GROUP,
+            CRD_VERSION,
+            'test-namespace',
+            CRD_PLURAL,
+            'test-job'
+        )
+
     def test_get_job_status_logs_and_returns_api_exception_reason(self):
         # Arrange
         self.mock_kubernetes_adapter.get_namespaced_custom_object.side_effect = ApiException(reason="Reason",

--- a/web_app_deployment/roles/docker/tasks/main.yml
+++ b/web_app_deployment/roles/docker/tasks/main.yml
@@ -3,6 +3,8 @@
   docker_image:
     name: "web_app:{{ git_tag }}"
     path: "/home/vagrant/synced/piezo/"
+    nocache: true
+    force: true
 
 - name: Retag Docker image
   shell: docker tag "web_app:{{ git_tag }}" "{{ harbor_url }}/piezo-resources/web_app:{{ git_tag }}"

--- a/web_app_deployment/roles/kubectl/tasks/main.yml
+++ b/web_app_deployment/roles/kubectl/tasks/main.yml
@@ -12,6 +12,7 @@
 
 - name: Delete old deployment
   shell: kubectl delete deployment piezo-web-app
+  ignore_errors: true
 
 - name: Apply deployment
   shell: kubectl apply -f "deploy_web_app_{{git_tag}}.yml"


### PR DESCRIPTION
Covers story #79 

Returns an "UNKNOWN" status of a job if the Kubernetes response does not contain the job status.

Also a few tweaks to the deployment process
* forcing a clean rebuild of the docker image
* ignoring an error deleting the old deployment (safer for the first time it is run)