### PR TITLE
Implement shorter character limit

### DIFF
--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -72,18 +72,18 @@ Submit Two Jobs With Same Name Returns Ok Responses
     Confirm Ok Response  ${response1}
     Confirm Ok Response  ${response2}
 
-Submit Job With 57 Character Name Runs Successfully
-    ${response}=    Submit SparkPi Job    abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefg
+Submit Job With 29 Character Name Runs Successfully
+    ${response}=    Submit SparkPi Job    abcdefghijklmnopqrstuvwxyzabc
     Confirm Ok Response  ${response}
     ${job_name}=    Get Response Job Name   ${response}
     ${finished}=    Wait For Spark Job To Finish        ${job_name}     5 seconds
     Should Be True      ${finished}
 
-Submit Job With 58 Character Name Fails
-    ${response}=    Submit SparkPi Job    abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefgh
+Submit Job With 30 Character Name Fails
+    ${response}=    Submit SparkPi Job    abcdefghijklmnopqrstuvwxyzabcd
     Confirm Bad Input Response  ${response}
     ${error}=   Get Response Data     ${response}
-    Should Be Equal As Strings    ${error}    The following errors were found:\n\"name\" input has a maximum length of 57 characters\n
+    Should Be Equal As Strings    ${error}    The following errors were found:\n\"name\" input has a maximum length of 29 characters\n
 
 Submit GroupByTest Spark Job With Arguments Returns Ok Response
     ${response}=    Submit SparkGroupByTest Job With Arguments   spark-group-by-test

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
@@ -26,8 +26,8 @@ def _validate_name(value):
         return validation_result
 
     # https://github.com/ukaea/piezo/wiki/WebAppDecisionRecord#maximum-length-of-a-job-name
-    if len(value) > 57:
-        return ValidationResult(False, '"name" input has a maximum length of 57 characters', None)
+    if len(value) > 29:
+        return ValidationResult(False, '"name" input has a maximum length of 29 characters', None)
 
     return ValidationResult(True, None, value)
 

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/argument_validator_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/argument_validator_test.py
@@ -36,27 +36,27 @@ def test_validate_name_rejects_non_string_values(name):
     assert validation_result.message == '"name" input must be a string'
 
 
-def test_validate_name_allows_57_character_name():
+def test_validate_name_allows_29_character_name():
     # Arrange
     validation_rule = ValidationRule({'classification': 'Required'})
-    name = 'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefg'
-    assert len(name) == 57
+    name = 'abcdefghijklmnopqrstuvwxyzabc'
+    assert len(name) == 29
     # Act
     validation_result = argument_validator.validate("name", name, validation_rule)
     # Assert
     assert validation_result.is_valid is True
 
 
-def test_validate_name_rejects_58_character_name():
+def test_validate_name_rejects_30_character_name():
     # Arrange
     validation_rule = ValidationRule({'classification': 'Required'})
-    name = 'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefg' + 'z'
-    assert len(name) == 58
+    name = 'abcdefghijklmnopqrstuvwxyzabc' + 'd'
+    assert len(name) == 30
     # Act
     validation_result = argument_validator.validate("name", name, validation_rule)
     # Assert
     assert validation_result.is_valid is False
-    assert validation_result.message == '"name" input has a maximum length of 57 characters'
+    assert validation_result.message == '"name" input has a maximum length of 29 characters'
 
 
 @pytest.mark.parametrize("language", ["Python", "Scala"])


### PR DESCRIPTION
Reduce the character limit for naming spark applicatiosn to 29 as explained here: https://github.com/ukaea/piezo/wiki/WebAppDecisionRecord#maximum-length-of-a-job-name

