### PR TITLE
Feature/remove namespace from handlers/#59

### DIFF
--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -19,7 +19,7 @@ Delete Request With Json Body
 
 Delete Spark Job
     [Arguments]   ${job_name}
-    ${body}=    Create Dictionary   job_name=${job_name}   namespace=default
+    ${body}=    Create Dictionary   job_name=${job_name}
     ${response}=  Delete Request With Json Body   /piezo/deletejob    ${body}
     [return]    ${response}
 
@@ -30,7 +30,7 @@ Get Driver Name
 
 Get Logs For Spark Job
     [Arguments]   ${job_name}
-    ${body}=    Create Dictionary   job_name=${job_name}   namespace=default
+    ${body}=    Create Dictionary   job_name=${job_name}
     ${response}=  Get Request With Json Body   /piezo/getlogs    ${body}
     [return]    ${response}
 
@@ -53,7 +53,7 @@ Get Request With Json Body
 
 Get Status Of Spark Job
     [Arguments]   ${job_name}
-    ${body}=    Create Dictionary   job_name=${job_name}   namespace=default
+    ${body}=    Create Dictionary   job_name=${job_name}
     ${response}=  Get Request With Json Body   /piezo/jobstatus    ${body}
     [return]    ${response}
 

--- a/piezo_web_app/PiezoWebApp/example_validation_rules.json
+++ b/piezo_web_app/PiezoWebApp/example_validation_rules.json
@@ -15,11 +15,6 @@
     "default": "SparkApplication"
   },
   {
-    "input_name": "namespace",
-    "classification": "Fixed",
-    "default": "default"
-  },
-  {
     "input_name": "mode",
     "classification": "Fixed",
     "default": "cluster"

--- a/piezo_web_app/PiezoWebApp/run_piezo.py
+++ b/piezo_web_app/PiezoWebApp/run_piezo.py
@@ -57,7 +57,7 @@ def build_container(configuration, k8s_adapter, log, validation_rules_path):
     validation_ruleset = ValidationRuleset(validation_rules)
     validation_service = ValidationService(validation_ruleset)
     manifest_populator = ManifestPopulator(configuration, validation_ruleset)
-    spark_job_namer = SparkJobNamer(k8s_adapter, validation_ruleset)
+    spark_job_namer = SparkJobNamer(k8s_adapter)
     spark_job_service = SparkJobService(k8s_adapter, log, manifest_populator, spark_job_namer, validation_service)
     container = dict(
         logger=log,

--- a/piezo_web_app/PiezoWebApp/src/handlers/delete_job.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/delete_job.py
@@ -8,20 +8,18 @@ from PiezoWebApp.src.handlers.schema.schema_helpers import create_object_schema_
 class DeleteJobHandler(BaseHandler):
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(
-            ['job_name', 'namespace'],
-            required=['job_name', 'namespace']),
+            ['job_name'],
+            required=['job_name']),
         input_example={
-            'job_name': 'example-spark-job',
-            'namespace': 'default'
+            'job_name': 'example-spark-job'
         }
     )
     def delete(self, *args, **kwargs):
         job_name = self.get_body_attribute('job_name', required=True)
-        namespace = self.get_body_attribute('namespace', required=True)
-        self._logger.debug(f'Trying to delete job "{job_name}" in namespace "{namespace}".')
-        result = self._spark_job_service.delete_job(job_name, namespace)
+        self._logger.debug(f'Trying to delete job "{job_name}".')
+        result = self._spark_job_service.delete_job(job_name)
         self._logger.debug(
-            f'Deleting job "{job_name}" in namespace "{namespace}" returned result "{result["status"]}".'
+            f'Deleting job "{job_name}" returned result "{result["status"]}".'
         )
         self.check_request_was_completed_successfully(result)
         del result['status']

--- a/piezo_web_app/PiezoWebApp/src/handlers/get_logs.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/get_logs.py
@@ -8,19 +8,17 @@ from PiezoWebApp.src.handlers.schema.schema_helpers import create_object_schema_
 class GetLogsHandler(BaseHandler):
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(
-            ['job_name', 'namespace'], required=['job_name', 'namespace']),
+            ['job_name'], required=['job_name']),
         input_example={
-            'job_name': 'example-job',
-            'namespace': 'default'
+            'job_name': 'example-job'
         }
     )
     def get(self, *args, **kwargs):
         job_name = self.get_body_attribute('job_name', required=True)
-        namespace = self.get_body_attribute('namespace', required=True)
-        self._logger.debug(f'Trying to get logs from spark job "{job_name}" in namespace "{namespace}".')
-        result = self._spark_job_service.get_logs(job_name, namespace)
+        self._logger.debug(f'Trying to get logs from spark job "{job_name}".')
+        result = self._spark_job_service.get_logs(job_name)
         self._logger.debug(
-            f'Getting logs from spark job "{job_name}" in namespace "{namespace}" returned result "{result["status"]}".'
+            f'Getting logs from spark job "{job_name}" returned result "{result["status"]}".'
         )
         self.check_request_was_completed_successfully(result)
         del result['status']

--- a/piezo_web_app/PiezoWebApp/src/handlers/job_status.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/job_status.py
@@ -8,19 +8,17 @@ from PiezoWebApp.src.handlers.schema.schema_helpers import create_object_schema_
 class JobStatusHandler(BaseHandler):
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(
-            ['job_name', 'namespace'], required=['job_name', 'namespace']),
+            ['job_name'], required=['job_name']),
         input_example={
-            'job_name': 'example-driver',
-            'namespace': 'default'
+            'job_name': 'example-driver'
         }
     )
     def get(self, *args, **kwargs):
         spark_job = self.get_body_attribute('job_name', required=True)
-        namespace = self.get_body_attribute('namespace', required=True)
-        self._logger.debug(f'Trying to get status of spark job "{spark_job}" in namespace "{namespace}".')
-        result = self._spark_job_service.get_job_status(spark_job, namespace)
+        self._logger.debug(f'Trying to get status of spark job "{spark_job}".')
+        result = self._spark_job_service.get_job_status(spark_job)
         self._logger.debug(
-            f'Getting status of spark job "{spark_job}" in namespace "{namespace}" returned '
+            f'Getting status of spark job "{spark_job}" returned '
             f'result "{result["status"]}".'
         )
         self.check_request_was_completed_successfully(result)

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
@@ -4,7 +4,7 @@ from abc import ABCMeta, abstractmethod
 class ISparkJobService(metaclass=ABCMeta):
 
     @abstractmethod
-    def delete_job(self, job_name, namespace):
+    def delete_job(self, job_name):
         pass
 
     @abstractmethod
@@ -12,11 +12,11 @@ class ISparkJobService(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_job_status(self, job_name, namespace):
+    def get_job_status(self, job_name):
         pass
 
     @abstractmethod
-    def get_logs(self, job_name, namespace):
+    def get_logs(self, job_name):
         pass
 
     @abstractmethod

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_constants.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_constants.py
@@ -6,3 +6,6 @@ CRD_PLURAL = 'sparkapplications'
 
 # str | The custom resource's version
 CRD_VERSION = 'v1beta1'
+
+# str | The namespace where all spark applications are run
+NAMESPACE = 'default'

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
@@ -11,7 +11,6 @@ from PiezoWebApp.src.services.spark_job.spark_job_constants import NAMESPACE
 
 class SparkJobNamer(ISparkJobNamer):
     def __init__(self, kubernetes_adapter):
-        self._namespace = NAMESPACE
         self._kubernetes_adapter = kubernetes_adapter
         self._max_attempts = 10
 
@@ -31,7 +30,7 @@ class SparkJobNamer(ISparkJobNamer):
             self._kubernetes_adapter.get_namespaced_custom_object(
                 CRD_GROUP,
                 CRD_VERSION,
-                self._namespace,
+                NAMESPACE,
                 CRD_PLURAL,
                 job_name
             )

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_namer.py
@@ -6,11 +6,12 @@ from PiezoWebApp.src.services.spark_job.i_spark_job_namer import ISparkJobNamer
 from PiezoWebApp.src.services.spark_job.spark_job_constants import CRD_GROUP
 from PiezoWebApp.src.services.spark_job.spark_job_constants import CRD_PLURAL
 from PiezoWebApp.src.services.spark_job.spark_job_constants import CRD_VERSION
+from PiezoWebApp.src.services.spark_job.spark_job_constants import NAMESPACE
 
 
 class SparkJobNamer(ISparkJobNamer):
-    def __init__(self, kubernetes_adapter, validation_ruleset):
-        self._namespace = validation_ruleset.get_default_value_for_key("namespace")
+    def __init__(self, kubernetes_adapter):
+        self._namespace = NAMESPACE
         self._kubernetes_adapter = kubernetes_adapter
         self._max_attempts = 10
 

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -79,7 +79,7 @@ class SparkJobService(ISparkJobService):
                 CRD_GROUP,
                 CRD_VERSION,
                 NAMESPACE,
-                CRD_PLURAL
+                CRD_PLURAL,
                 **kwargs
             )
             spark_jobs = {

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
@@ -6,7 +6,6 @@ from PiezoWebApp.src.utils.dict_argument_helper import set_value_in_nested_dict
 class ManifestPopulator(IManifestPopulator):
     def __init__(self, configuration, validation_rules):
         self._validation_rules = validation_rules
-        self._metadata_namespace = NAMESPACE
         self._arguments = self._validation_rules.get_default_value_for_key("arguments")
         self._api_version = self._validation_rules.get_default_value_for_key("apiVersion")
         self._kind = self._validation_rules.get_default_value_for_key("kind")
@@ -50,7 +49,7 @@ class ManifestPopulator(IManifestPopulator):
                 "kind": self._kind,
                 "metadata":
                     {"name": self._metadata_name,
-                     "namespace": self._metadata_namespace},
+                     "namespace": NAMESPACE},
                 "spec": {
                     "mode": self._spec_mode,
                     "image": self._spec_image,

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
@@ -1,3 +1,4 @@
+from PiezoWebApp.src.services.spark_job.spark_job_constants import NAMESPACE
 from PiezoWebApp.src.services.spark_job.validation.i_manifest_populator import IManifestPopulator
 from PiezoWebApp.src.utils.dict_argument_helper import set_value_in_nested_dict
 
@@ -5,11 +6,11 @@ from PiezoWebApp.src.utils.dict_argument_helper import set_value_in_nested_dict
 class ManifestPopulator(IManifestPopulator):
     def __init__(self, configuration, validation_rules):
         self._validation_rules = validation_rules
+        self._metadata_namespace = NAMESPACE
         self._arguments = self._validation_rules.get_default_value_for_key("arguments")
         self._api_version = self._validation_rules.get_default_value_for_key("apiVersion")
         self._kind = self._validation_rules.get_default_value_for_key("kind")
         self._metadata_name = self._validation_rules.get_default_value_for_key("name")
-        self._metadata_namespace = self._validation_rules.get_default_value_for_key("namespace")
         self._metadata_label = self._validation_rules.get_default_value_for_key("label")
         self._spec_type = self._validation_rules.get_default_value_for_key("language")
         self._spec_mode = self._validation_rules.get_default_value_for_key("mode")

--- a/piezo_web_app/PiezoWebApp/tests/handlers/base_handler_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/base_handler_test.py
@@ -67,12 +67,26 @@ class BaseHandlerTest(AsyncHTTPTestCase, metaclass=ABCMeta):
         assert "Server" not in response.headers
         return response
 
+    async def _request_without_body(self, method):
+        response = await self.http_client.fetch(
+            self.url,
+            method=method,
+            allow_nonstandard_methods=True
+        )
+        assert "Server" not in response.headers
+        return response
+
     @staticmethod
     def _get_body(response):
         return json.loads(response.body, encoding='utf-8')
 
     async def send_request(self, body):
         response = await self._request(self.standard_request_method, body)
+        response_body = BaseHandlerTest._get_body(response)
+        return response_body, response.code
+
+    async def send_request_without_body(self):
+        response = await self._request_without_body(self.standard_request_method)
         response_body = BaseHandlerTest._get_body(response)
         return response_body, response.code
 

--- a/piezo_web_app/PiezoWebApp/tests/handlers/delete_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/delete_job_test.py
@@ -19,42 +19,37 @@ class TestDeleteJobHandler(BaseHandlerTest):
 
     @gen_test
     def test_delete_returns_400_when_job_name_is_missing(self):
-        body = {'namespace': 'test-namespace'}
-        yield self.assert_request_returns_400(body)
-
-    @gen_test
-    def test_delete_returns_400_when_namespace_is_missing(self):
-        body = {'job_name': 'test-spark-job'}
+        body = {}
         yield self.assert_request_returns_400(body)
 
     @gen_test
     def test_delete_returns_success_confirmation_when_successful(self):
         # Arrange
-        body = {'job_name': 'test-spark-job', 'namespace': 'test-namespace'}
+        body = {'job_name': 'test-spark-job'}
         self.mock_spark_job_service.delete_job.return_value = {
-            "message": "test-spark-job deleted from namespace test-namespace",
+            "message": "test-spark-job deleted",
             'status': 200
         }
         # Act
         response_body, response_code = yield self.send_request(body)
         # Assert
-        self.mock_spark_job_service.delete_job.assert_called_once_with('test-spark-job', 'test-namespace')
+        self.mock_spark_job_service.delete_job.assert_called_once_with('test-spark-job')
         self.mock_logger.debug.assert_has_calls([
-            call('Trying to delete job "test-spark-job" in namespace "test-namespace".'),
-            call('Deleting job "test-spark-job" in namespace "test-namespace" returned result "200".')
+            call('Trying to delete job "test-spark-job".'),
+            call('Deleting job "test-spark-job" returned result "200".')
         ])
         assert response_code == 200
         self.assertDictEqual(response_body, {
             'status': 'success',
             'data': {
-                'message': "test-spark-job deleted from namespace test-namespace"
+                'message': "test-spark-job deleted"
             }
         })
 
     @gen_test
     def test_delete_returns_message_and_status_code_when_k8s_error(self):
         # Arrange
-        body = {'job_name': 'test-spark-job', 'namespace': 'test-namespace'}
+        body = {'job_name': 'test-spark-job'}
         self.mock_spark_job_service.delete_job.return_value = {
             "message": "Kubernetes error",
             'status': 422

--- a/piezo_web_app/PiezoWebApp/tests/handlers/delete_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/delete_job_test.py
@@ -3,6 +3,7 @@ from mock import call
 import pytest
 from tornado.httpclient import HTTPClientError
 from tornado.testing import gen_test
+from jsonschema.exceptions import ValidationError
 
 from PiezoWebApp.tests.handlers.base_handler_test import BaseHandlerTest
 from PiezoWebApp.src.handlers.delete_job import DeleteJobHandler
@@ -60,3 +61,12 @@ class TestDeleteJobHandler(BaseHandlerTest):
         assert error.value.response.code == 422
         msg = json.loads(error.value.response.body, encoding='utf-8')['data']
         assert msg == "Kubernetes error"
+
+    @gen_test
+    def test_delete_returns_input_malformed_message_if_no_body_provided(self):
+        # Act
+        with pytest.raises(HTTPClientError) as error:
+            yield self.send_request_without_body()
+        assert error.value.response.code == 400
+        msg = json.loads(error.value.response.body, encoding='utf-8')['data']
+        assert msg == 'Input is malformed; could not decode JSON object.'

--- a/piezo_web_app/PiezoWebApp/tests/handlers/delete_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/delete_job_test.py
@@ -3,7 +3,6 @@ from mock import call
 import pytest
 from tornado.httpclient import HTTPClientError
 from tornado.testing import gen_test
-from jsonschema.exceptions import ValidationError
 
 from PiezoWebApp.tests.handlers.base_handler_test import BaseHandlerTest
 from PiezoWebApp.src.handlers.delete_job import DeleteJobHandler

--- a/piezo_web_app/PiezoWebApp/tests/handlers/get_jobs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/get_jobs_test.py
@@ -1,4 +1,8 @@
+import json
+import pytest
+
 from mock import call
+from tornado.httpclient import HTTPClientError
 from tornado.testing import gen_test
 
 from PiezoWebApp.tests.handlers.base_handler_test import BaseHandlerTest
@@ -88,3 +92,12 @@ class TestGetJobsHandler(BaseHandlerTest):
                 'spark_jobs': {"job_1": "COMPLETED", "job_3": "PENDING"}
             }
         })
+
+    @gen_test
+    def test_get_returns_input_malformed_message_if_no_body_provided(self):
+        # Act
+        with pytest.raises(HTTPClientError) as error:
+            yield self.send_request_without_body()
+        assert error.value.response.code == 400
+        msg = json.loads(error.value.response.body, encoding='utf-8')['data']
+        assert msg == 'Input is malformed; could not decode JSON object.'

--- a/piezo_web_app/PiezoWebApp/tests/handlers/get_logs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/get_logs_test.py
@@ -1,5 +1,9 @@
+import json
+import pytest
+
 from mock import call
 from tornado.testing import gen_test
+from tornado.httpclient import HTTPClientError
 
 from PiezoWebApp.tests.handlers.base_handler_test import BaseHandlerTest
 from PiezoWebApp.src.handlers.get_logs import GetLogsHandler
@@ -42,3 +46,12 @@ class TestGetLogsHandler(BaseHandlerTest):
                 'message': 'logs'
             }
         })
+
+    @gen_test
+    def test_get_returns_input_malformed_message_if_no_body_provided(self):
+        # Act
+        with pytest.raises(HTTPClientError) as error:
+            yield self.send_request_without_body()
+        assert error.value.response.code == 400
+        msg = json.loads(error.value.response.body, encoding='utf-8')['data']
+        assert msg == 'Input is malformed; could not decode JSON object.'

--- a/piezo_web_app/PiezoWebApp/tests/handlers/get_logs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/get_logs_test.py
@@ -16,18 +16,13 @@ class TestGetLogsHandler(BaseHandlerTest):
 
     @gen_test
     def test_get_returns_400_when_driver_name_is_missing(self):
-        body = {'namespace': 'test-namespace'}
-        yield self.assert_request_returns_400(body)
-
-    @gen_test
-    def test_get_returns_400_when_namespace_is_missing(self):
-        body = {'job_name': 'test-job'}
+        body = {}
         yield self.assert_request_returns_400(body)
 
     @gen_test
     def test_get_returns_logs_when_successful(self):
         # Arrange
-        body = {'job_name': 'test-job', 'namespace': 'test-namespace'}
+        body = {'job_name': 'test-job'}
         self.mock_spark_job_service.get_logs.return_value = {
             "message": "logs",
             "status": 200
@@ -35,10 +30,10 @@ class TestGetLogsHandler(BaseHandlerTest):
         # Act
         response_body, response_code = yield self.send_request(body)
         # Assert
-        self.mock_spark_job_service.get_logs.assert_called_once_with('test-job', 'test-namespace')
+        self.mock_spark_job_service.get_logs.assert_called_once_with('test-job')
         self.mock_logger.debug.assert_has_calls([
-            call('Trying to get logs from spark job "test-job" in namespace "test-namespace".'),
-            call('Getting logs from spark job "test-job" in namespace "test-namespace" returned result "200".')
+            call('Trying to get logs from spark job "test-job".'),
+            call('Getting logs from spark job "test-job" returned result "200".')
         ])
         assert response_code == 200
         self.assertDictEqual(response_body, {

--- a/piezo_web_app/PiezoWebApp/tests/handlers/job_status_handler_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/job_status_handler_test.py
@@ -62,3 +62,12 @@ class TestJobStatusHandler(BaseHandlerTest):
         assert error.value.response.code == 404
         msg = json.loads(error.value.response.body, encoding='utf-8')['data']
         assert msg == "Kubernetes error"
+
+    @gen_test
+    def test_get_returns_input_malformed_message_if_no_body_provided(self):
+        # Act
+        with pytest.raises(HTTPClientError) as error:
+            yield self.send_request_without_body()
+        assert error.value.response.code == 400
+        msg = json.loads(error.value.response.body, encoding='utf-8')['data']
+        assert msg == 'Input is malformed; could not decode JSON object.'

--- a/piezo_web_app/PiezoWebApp/tests/handlers/job_status_handler_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/job_status_handler_test.py
@@ -20,18 +20,13 @@ class TestJobStatusHandler(BaseHandlerTest):
 
     @gen_test
     def test_get_returns_400_when_job_name_is_missing(self):
-        body = {'namespace': 'test-namespace'}
-        yield self.assert_request_returns_400(body)
-
-    @gen_test
-    def test_get_returns_400_when_namespace_is_missing(self):
-        body = {'job_name': 'test-driver'}
+        body = {}
         yield self.assert_request_returns_400(body)
 
     @gen_test
     def test_get_returns_status_when_successful(self):
         # Arrange
-        body = {'job_name': 'test-job', 'namespace': 'test-namespace'}
+        body = {'job_name': 'test-job'}
         self.mock_spark_job_service.get_job_status.return_value = {
             "message": "status",
             "status": 200
@@ -39,10 +34,10 @@ class TestJobStatusHandler(BaseHandlerTest):
         # Act
         response_body, response_code = yield self.send_request(body)
         # Assert
-        self.mock_spark_job_service.get_job_status.assert_called_once_with('test-job', 'test-namespace')
+        self.mock_spark_job_service.get_job_status.assert_called_once_with('test-job')
         self.mock_logger.debug.assert_has_calls([
-            call('Trying to get status of spark job "test-job" in namespace "test-namespace".'),
-            call('Getting status of spark job "test-job" in namespace "test-namespace" returned '
+            call('Trying to get status of spark job "test-job".'),
+            call('Getting status of spark job "test-job" returned '
                  'result "200".')
         ])
         assert response_code == 200
@@ -56,7 +51,7 @@ class TestJobStatusHandler(BaseHandlerTest):
     @gen_test
     def test_get_returns_message_and_status_code_when_k8s_error(self):
         # Arrange
-        body = {'job_name': 'test-job', 'namespace': 'test-namespace'}
+        body = {'job_name': 'test-job'}
         self.mock_spark_job_service.get_job_status.return_value = {
             "message": "Kubernetes error",
             "status": 404

--- a/piezo_web_app/PiezoWebApp/tests/handlers/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/submit_job_test.py
@@ -1,5 +1,9 @@
+import json
+import pytest
+
 from mock import call
 from tornado.testing import gen_test
+from tornado.httpclient import HTTPClientError
 
 from PiezoWebApp.tests.handlers.base_handler_test import BaseHandlerTest
 from PiezoWebApp.src.handlers.submit_job import SubmitJobHandler
@@ -183,3 +187,12 @@ class TestSubmitJobHandler(BaseHandlerTest):
         # Assert
         self.mock_spark_job_service.submit_job.assert_called_once_with(body)
         assert response_code == 200
+
+    @gen_test
+    def test_post_returns_input_malformed_message_if_no_body_provided(self):
+        # Act
+        with pytest.raises(HTTPClientError) as error:
+            yield self.send_request_without_body()
+        assert error.value.response.code == 400
+        msg = json.loads(error.value.response.body, encoding='utf-8')['data']
+        assert msg == 'Input is malformed; could not decode JSON object.'

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/delete_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/delete_job_test.py
@@ -66,4 +66,4 @@ class DeleteJobIntegrationTest(BaseIntegrationTest):
             yield self.send_request(body)
         assert exception.value.response.code == 404
         msg = json.loads(exception.value.response.body, encoding='utf-8')['data']
-        assert msg == 'Kubernetes error when trying to delete job: Not Found'
+        assert msg == 'Kubernetes error when trying to delete job "test-spark-job": Not Found'

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/example_validation_rules.json
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/example_validation_rules.json
@@ -15,11 +15,6 @@
     "default": "SparkApplication"
   },
   {
-    "input_name": "namespace",
-    "classification": "Fixed",
-    "default": "default"
-  },
-  {
     "input_name": "mode",
     "classification": "Fixed",
     "default": "cluster"

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/get_jobs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/get_jobs_test.py
@@ -13,6 +13,8 @@ CRD_PLURAL = 'sparkapplications'
 # str | The custom resource's version
 CRD_VERSION = 'v1beta1'
 
+NAMESPACE = 'default'
+
 
 class TestGetJobsIntegration(BaseIntegrationTest):
     @property
@@ -62,7 +64,7 @@ class TestGetJobsIntegration(BaseIntegrationTest):
         assert self.mock_k8s_adapter.list_namespaced_custom_object.call_count == 1
         self.mock_k8s_adapter.list_namespaced_custom_object.assert_called_once_with(CRD_GROUP,
                                                                                     CRD_VERSION,
-                                                                                    'default',
+                                                                                    NAMESPACE,
                                                                                     CRD_PLURAL)
         assert response_code == 200
         self.assertDictEqual(response_body, {

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
@@ -19,6 +19,8 @@ CRD_PLURAL = 'sparkapplications'
 # str | The custom resource's version
 CRD_VERSION = 'v1beta1'
 
+NAMESPACE = 'default'
+
 
 class TestSubmitJobIntegration(BaseIntegrationTest):
     @property
@@ -49,7 +51,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         self.mock_k8s_adapter.get_namespaced_custom_object.assert_called_once_with(
             CRD_GROUP,
             CRD_VERSION,
-            'default',
+            NAMESPACE,
             CRD_PLURAL,
             'test_python_job-abcd1'
         )
@@ -118,7 +120,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         call_args = self.mock_k8s_adapter.create_namespaced_custom_object.call_args[0]
         assert call_args[0] == CRD_GROUP
         assert call_args[1] == CRD_VERSION
-        assert call_args[2] == 'default'
+        assert call_args[2] == NAMESPACE
         assert call_args[3] == CRD_PLURAL
         self.assertDictEqual(call_args[4], expected_body)
         assert response_code == 200
@@ -150,7 +152,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         self.mock_k8s_adapter.get_namespaced_custom_object.assert_called_once_with(
             CRD_GROUP,
             CRD_VERSION,
-            'default',
+            NAMESPACE,
             CRD_PLURAL,
             'test_scala_job-abcd1'
         )
@@ -219,7 +221,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         call_args = self.mock_k8s_adapter.create_namespaced_custom_object.call_args[0]
         assert call_args[0] == CRD_GROUP
         assert call_args[1] == CRD_VERSION
-        assert call_args[2] == 'default'
+        assert call_args[2] == NAMESPACE
         assert call_args[3] == CRD_PLURAL
         self.assertDictEqual(call_args[4], expected_body)
         assert response_code == 200
@@ -256,7 +258,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         self.mock_k8s_adapter.get_namespaced_custom_object.assert_called_once_with(
             CRD_GROUP,
             CRD_VERSION,
-            'default',
+            NAMESPACE,
             CRD_PLURAL,
             'test_python_job-abcd1'
         )
@@ -327,7 +329,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
         call_args = self.mock_k8s_adapter.create_namespaced_custom_object.call_args[0]
         assert call_args[0] == CRD_GROUP
         assert call_args[1] == CRD_VERSION
-        assert call_args[2] == 'default'
+        assert call_args[2] == NAMESPACE
         assert call_args[3] == CRD_PLURAL
         self.assertDictEqual(call_args[4], expected_body)
         assert response_code == 200

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_namer_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_namer_test.py
@@ -6,17 +6,14 @@ import pytest
 
 from PiezoWebApp.src.services.kubernetes.i_kubernetes_adapter import IKubernetesAdapter
 from PiezoWebApp.src.services.spark_job.spark_job_namer import SparkJobNamer
-from PiezoWebApp.src.services.spark_job.validation.validation_ruleset import ValidationRuleset
 
 
 class TestSparkJobNamer(TestCase):
     # pylint: disable=attribute-defined-outside-init
     @pytest.fixture(autouse=True)
     def setup(self):
-        mock_validation_ruleset = mock.create_autospec(ValidationRuleset)
-        mock_validation_ruleset.get_default_value_for_key.return_value = "default"
         self.mock_kubernetes_adapter = mock.create_autospec(IKubernetesAdapter)
-        self.test_namer = SparkJobNamer(self.mock_kubernetes_adapter, mock_validation_ruleset)
+        self.test_namer = SparkJobNamer(self.mock_kubernetes_adapter)
 
     def test_rename_job_tags_names_with_uuid(self):
         # Arrange

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -22,6 +22,8 @@ CRD_PLURAL = 'sparkapplications'
 # str | The custom resource's version
 CRD_VERSION = 'v1beta1'
 
+NAMESPACE = 'default'
+
 
 class TestSparkJobService(TestCase):
     # pylint: disable=attribute-defined-outside-init
@@ -46,13 +48,13 @@ class TestSparkJobService(TestCase):
         self.mock_kubernetes_adapter.delete_options.return_value = {"api_version": "version", "other_values": "values"}
         self.mock_kubernetes_adapter.delete_namespaced_custom_object.return_value = k8s_response
         # Act
-        result = self.test_service.delete_job('test-spark-job', 'test-namespace')
+        result = self.test_service.delete_job('test-spark-job')
         # Assert
-        self.assertDictEqual(result, {'message': 'test-spark-job deleted from namespace test-namespace', 'status': 200})
+        self.assertDictEqual(result, {'message': 'test-spark-job deleted', 'status': 200})
         self.mock_kubernetes_adapter.delete_namespaced_custom_object.assert_called_once_with(
             CRD_GROUP,
             CRD_VERSION,
-            'test-namespace',
+            NAMESPACE,
             CRD_PLURAL,
             'test-spark-job',
             {"api_version": "version", "other_values": "values"}
@@ -65,10 +67,10 @@ class TestSparkJobService(TestCase):
             status=999
         )
         # Act
-        result = self.test_service.delete_job('test-spark-job', 'test-namespace')
+        result = self.test_service.delete_job('test-spark-job')
         # Assert
         expected_message = \
-            'Kubernetes error when trying to delete job "test-spark-job" in namespace "test-namespace": Reason'
+            'Kubernetes error when trying to delete job "test-spark-job": Reason'
         self.mock_logger.error.assert_called_once_with(expected_message)
         assert result['status'] == 999
         assert result['message'] == expected_message
@@ -130,25 +132,24 @@ class TestSparkJobService(TestCase):
         # Arrange
         self.mock_kubernetes_adapter.read_namespaced_pod_log.return_value = "Response"
         # Act
-        result = self.test_service.get_logs('test-job', 'test-namespace')
+        result = self.test_service.get_logs('test-job')
         # Assert
         self.assertDictEqual(result, {'message': 'Response', 'status': 200})
         self.mock_kubernetes_adapter.read_namespaced_pod_log.assert_called_once_with(
-            'test-job-driver', 'test-namespace')
+            'test-job-driver', 'default')
 
     def test_get_logs_logs_and_returns_api_exception_reason(self):
         # Arrange
         self.mock_kubernetes_adapter.read_namespaced_pod_log.side_effect = ApiException(reason="Reason", status=999)
         # Act
-        result = self.test_service.get_logs('test-job', 'test-namespace')
+        result = self.test_service.get_logs('test-job')
         # Assert
         expected_message = \
-            'Kubernetes error when trying to get logs for spark job "test-job" in namespace "test-namespace": Reason'
+            'Kubernetes error when trying to get logs for spark job "test-job": Reason'
         self.mock_logger.error.assert_called_once_with(expected_message)
         self.assertDictEqual(result, {
             'status': 999,
-            'message': 'Kubernetes error when trying to get logs for spark job "test-job" '
-                       'in namespace "test-namespace": Reason'
+            'message': 'Kubernetes error when trying to get logs for spark job "test-job": Reason'
         })
 
     def test_submit_job_sends_expected_arguments(self):
@@ -162,7 +163,7 @@ class TestSparkJobService(TestCase):
         self.mock_spark_job_namer.rename_job.return_value = 'test-spark-job-abcd1234'
         manifest = {
             'metadata': {
-                'namespace': 'example-namespace',
+                'namespace': NAMESPACE,
                 'name': 'test-spark-job-abcd1234',
                 'language': 'example-language'
             }
@@ -170,7 +171,7 @@ class TestSparkJobService(TestCase):
         self.mock_manifest_populator.build_manifest.return_value = manifest
         self.mock_kubernetes_adapter.create_namespaced_custom_object.return_value = {
             'metadata': {
-                'namespace': 'example-namespace',
+                'namespace': NAMESPACE,
                 'name': 'test-spark-job-abcd1234',
                 'language': 'example-language'
             }
@@ -181,7 +182,7 @@ class TestSparkJobService(TestCase):
         self.mock_kubernetes_adapter.create_namespaced_custom_object.assert_called_once_with(
             CRD_GROUP,
             CRD_VERSION,
-            'example-namespace',
+            NAMESPACE,
             CRD_PLURAL,
             manifest
         )
@@ -235,7 +236,7 @@ class TestSparkJobService(TestCase):
         self.mock_spark_job_namer.rename_job.return_value = 'test-spark-job-abcd1234'
         manifest = {
             'metadata': {
-                'namespace': 'example-namespace',
+                'namespace': NAMESPACE,
                 'name': 'test-spark-job-abcd1234',
                 'language': 'example-language'
             }
@@ -249,7 +250,7 @@ class TestSparkJobService(TestCase):
         self.mock_kubernetes_adapter.create_namespaced_custom_object.assert_called_once_with(
             CRD_GROUP,
             CRD_VERSION,
-            'example-namespace',
+            NAMESPACE,
             CRD_PLURAL,
             manifest
         )
@@ -258,7 +259,7 @@ class TestSparkJobService(TestCase):
             mock.call(expected_message),
             mock.call({
                 'metadata': {
-                    'namespace': 'example-namespace',
+                    'namespace': NAMESPACE,
                     'name': 'test-spark-job-abcd1234',
                     'language': 'example-language'
                 }
@@ -276,13 +277,13 @@ class TestSparkJobService(TestCase):
                 'applicationState': {
                     'state': 'Running'}}}
         # Act
-        result = self.test_service.get_job_status('test-job', 'test-namespace')
+        result = self.test_service.get_job_status('test-job')
         # Assert
         self.assertDictEqual(result, {'message': 'Running', 'status': 200})
         self.mock_kubernetes_adapter.get_namespaced_custom_object.assert_called_once_with(
             CRD_GROUP,
             CRD_VERSION,
-            'test-namespace',
+            NAMESPACE,
             CRD_PLURAL,
             'test-job'
         )
@@ -291,13 +292,13 @@ class TestSparkJobService(TestCase):
         # Arrange
         self.mock_kubernetes_adapter.get_namespaced_custom_object.return_value = {'name': 'test-job'}
         # Act
-        result = self.test_service.get_job_status('test-job', 'test-namespace')
+        result = self.test_service.get_job_status('test-job')
         # Assert
         self.assertDictEqual(result, {'message': 'UNKNOWN', 'status': 200})
         self.mock_kubernetes_adapter.get_namespaced_custom_object.assert_called_once_with(
             CRD_GROUP,
             CRD_VERSION,
-            'test-namespace',
+            NAMESPACE,
             CRD_PLURAL,
             'test-job'
         )
@@ -307,14 +308,12 @@ class TestSparkJobService(TestCase):
         self.mock_kubernetes_adapter.get_namespaced_custom_object.side_effect = ApiException(reason="Reason",
                                                                                              status=999)
         # Act
-        result = self.test_service.get_job_status('test-job', 'test-namespace')
+        result = self.test_service.get_job_status('test-job')
         # Assert
         expected_message = \
-            'Kubernetes error when trying to get status of spark job "test-job" in ' \
-            'namespace "test-namespace": Reason'
+            'Kubernetes error when trying to get status of spark job "test-job": Reason'
         self.mock_logger.error.assert_called_once_with(expected_message)
         self.assertDictEqual(result, {
             'status': 999,
-            'message': 'Kubernetes error when trying to get status of spark job "test-job" in namespace'
-                       ' "test-namespace": Reason'
+            'message': 'Kubernetes error when trying to get status of spark job "test-job": Reason'
         })


### PR DESCRIPTION
Changes included:
 * Remove namespace from the handler arguments and move it to the spark job constants
 * Update the wiki [user guide](https://github.com/ukaea/piezo/wiki/WebAppUserGuide) to reflect this change
 * Update tests to incorporate the change

## Stories covered:
#59 

## To test:
Run system and unit tests
