### PR TITLE
Feature/temorary urls for log files #89

### DIFF
--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -58,6 +58,12 @@ Get Status Of Spark Job
     ${response}=  Get Request With Json Body   /piezo/jobstatus    ${body}
     [return]    ${response}
 
+Output Files Of Spark Job
+    [Arguments]   ${job_name}
+    ${body}=    Create Dictionary   job_name=${job_name}
+    ${response}=  Get Request With Json Body   /piezo/outputfiles    ${body}
+    [return]    ${response.json()["data"]["files"]}
+
 Post Request With Json Body
     [Arguments]   ${route}    ${body}
     ${headers}=   Json Header

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -269,3 +269,26 @@ Tidy Jobs Writes Logs And Deletes Completed Jobs
     ${tidied_jobs}=    Get Response Tidied Jobs     ${request_response}
     Dictionary Should Contain Item    ${tidied_jobs}    ${new_job_name1}    COMPLETED
     Dictionary Should Contain Item    ${tidied_jobs}    ${new_job_name2}    COMPLETED
+
+Output Files Provides Temporary URLs
+    ${job_name}=    Set Variable   wordcount-tempurl
+    ${response}=    Submit Wordcount On Minio Job   ${job_name}
+    Confirm Ok Response  ${response}
+    ${new_job_name}=    Get Response Job Name   ${response}
+    ${finished}=    Wait For Spark Job To Finish        ${new_job_name}     15 seconds
+    Should Be True    ${finished}
+    Write Logs To Storage   ${new_job_name}
+    ${output_files}=    Output Files Of Spark Job   ${job_name}
+    ${success_file}=    Download From Temporary URL   ${output_files["_SUCCESS"]}
+    ${line_count}=    Get Line Count    ${success_file}
+    Should Be Equal As Integers   ${line_count}   0
+    ${part0_file}=    Download From Temporary URL   ${output_files["part-00000"]}
+    ${line_count}=    Get Line Count    ${part0_file}
+    Should Be True   ${line_count} > 0
+    ${part1_file}=    Download From Temporary URL   ${output_files["part-00001"]}
+    ${line_count}=    Get Line Count    ${part1_file}
+    Should Be True   ${line_count} > 0
+    ${output_files}=    Output Files Of Spark Job   ${new_job_name}
+    ${log_file}=    Download From Temporary URL   ${output_files["log.txt"]}
+    ${line_count}=    Get Line Count    ${log_file}
+    Should Be True   ${line_count} > 0

--- a/SystemTests/roles/robot/files/s3methods.robot
+++ b/SystemTests/roles/robot/files/s3methods.robot
@@ -6,6 +6,7 @@ Library           OperatingSystem
 ###############################################################################
 *** Variables ***
 ${MINIO_ROOT}     /opt/minio/data/
+${S3_LOCATION}    http://172.16.113.201:9000/
 
 ###############################################################################
 *** Keywords ***
@@ -20,6 +21,14 @@ Directory Should Not Exist In S3 Bucket
 Directory Should Not Be Empty In S3 Bucket
     [Arguments]   ${bucket-name}    ${dir-path}
     Directory Should Not Be Empty     ${MINIO_ROOT}/${bucket-name}/${dir-path}
+
+Download From Temporary URL
+    [Arguments]   ${url}
+    ${file_loc}=    Set Variable    ~/temp.txt
+    ${rc}   ${output}=    Run And Return Rc And Output    wget -O ${file_loc} "${url}"
+    ${file}=    Get File    ${file_loc}
+    Remove File   ${file_loc}
+    [return]    ${file}
 
 File Should Exist In S3 Bucket
     [Arguments]   ${bucket-name}    ${file-path}

--- a/piezo_web_app/PiezoWebApp/example_configuration.ini
+++ b/piezo_web_app/PiezoWebApp/example_configuration.ini
@@ -12,3 +12,4 @@ TidyFrequency = 3600
 S3Endpoint = URL_OF_S3
 S3KeysSecret = NAME_OF_SECRET_CONTAINING_S3_KEYS
 SecretsDir = /etc/secrets/
+TempUrlExpirySeconds = 600

--- a/piezo_web_app/PiezoWebApp/run_piezo.py
+++ b/piezo_web_app/PiezoWebApp/run_piezo.py
@@ -12,6 +12,7 @@ from PiezoWebApp.src.handlers.get_jobs import GetJobsHandler
 from PiezoWebApp.src.handlers.get_logs import GetLogsHandler
 from PiezoWebApp.src.handlers.heartbeat_handler import HeartbeatHandler
 from PiezoWebApp.src.handlers.job_status import JobStatusHandler
+from PiezoWebApp.src.handlers.output_files_handler import OutputFilesHandler
 from PiezoWebApp.src.handlers.submit_job import SubmitJobHandler
 from PiezoWebApp.src.handlers.tidy_jobs import TidyJobsHandler
 from PiezoWebApp.src.handlers.write_logs_handler import WriteLogsHandler
@@ -90,6 +91,7 @@ def build_app(container, use_route_stem=False):
             (format_route_specification(route_stem + 'getjobs'), GetJobsHandler, container),
             (format_route_specification(route_stem + 'getlogs'), GetLogsHandler, container),
             (format_route_specification(route_stem + 'jobstatus'), JobStatusHandler, container),
+            (format_route_specification(route_stem + 'outputfiles'), OutputFilesHandler, container),
             (format_route_specification(route_stem + 'submitjob'), SubmitJobHandler, container),
             (format_route_specification(route_stem + 'tidyjobs'), TidyJobsHandler, container),
             (format_route_specification(route_stem + 'writelogs'), WriteLogsHandler, container)

--- a/piezo_web_app/PiezoWebApp/src/handlers/job_status.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/job_status.py
@@ -10,7 +10,7 @@ class JobStatusHandler(BaseHandler):
         input_schema=create_object_schema_with_string_properties(
             ['job_name'], required=['job_name']),
         input_example={
-            'job_name': 'example-driver'
+            'job_name': 'example-job'
         }
     )
     def get(self, *args, **kwargs):

--- a/piezo_web_app/PiezoWebApp/src/handlers/output_files_handler.py
+++ b/piezo_web_app/PiezoWebApp/src/handlers/output_files_handler.py
@@ -1,0 +1,25 @@
+from tornado_json import schema
+
+from PiezoWebApp.src.handlers.base_handler import BaseHandler
+from PiezoWebApp.src.handlers.schema.schema_helpers import create_object_schema_with_string_properties
+
+
+# pylint: disable=abstract-method
+class OutputFilesHandler(BaseHandler):
+    @schema.validate(
+        input_schema=create_object_schema_with_string_properties(
+            ['job_name'], required=['job_name']),
+        input_example={
+            'job_name': 'example-job'
+        }
+    )
+    def get(self, *args, **kwargs):
+        spark_job = self.get_body_attribute('job_name', required=True)
+        self._logger.debug(f'Trying to get output files for spark job "{spark_job}".')
+        result = self._spark_job_service.get_output_files_temp_urls(spark_job)
+        self._logger.debug(
+            f'Getting output files for spark job "{spark_job}" returned result "{result["status"]}".'
+        )
+        self.check_request_was_completed_successfully(result)
+        del result['status']
+        return result

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/i_spark_job_service.py
@@ -20,6 +20,10 @@ class ISparkJobService(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def get_output_files_temp_urls(self, job_name):
+        pass
+
+    @abstractmethod
     def submit_job(self, body):
         pass
 

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -142,7 +142,11 @@ class SparkJobService(ISparkJobService):
         output_dir = self._job_output_dir_path(job_name)
         temp_urls = self._storage_adapter.get_temp_url_for_each_file(self._bucket_name, output_dir)
         self._logger.debug(f'Got temporary URLs for {len(temp_urls)} output files for job "{job_name}"')
-        return temp_urls
+        status = StatusCodes.Okay if temp_urls else StatusCodes.Not_found
+        return {
+            'files': temp_urls,
+            'status': status.value
+        }
 
     def submit_job(self, body):
         # Validate the body keys

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -1,4 +1,5 @@
 import asyncio
+from os.path import basename
 
 from kubernetes.client.rest import ApiException
 
@@ -141,6 +142,7 @@ class SparkJobService(ISparkJobService):
     def get_output_files_temp_urls(self, job_name):
         output_dir = self._job_output_dir_path(job_name)
         temp_urls = self._storage_adapter.get_temp_url_for_each_file(self._bucket_name, output_dir)
+        temp_urls = {basename(file_path): temp_url for file_path, temp_url in temp_urls.items()}
         msg = f'Got temporary URLs for {len(temp_urls)} output files for job "{job_name}"'
         self._logger.debug(msg)
         status = StatusCodes.Okay if temp_urls else StatusCodes.Not_found

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -213,7 +213,7 @@ class SparkJobService(ISparkJobService):
         if api_response['status'] != StatusCodes.Okay.value:
             return api_response
         try:
-            file_name = f'{self._job_output_dir_path(job_name)}/log.txt'
+            file_name = f'{self._job_output_dir_path(job_name)}log.txt'
             self._storage_adapter.set_contents_from_string(self._bucket_name, file_name, api_response['message'])
             msg = f'Logs written to "{file_name}" in bucket "{self._bucket_name}"'
             self._logger.debug(msg)

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -20,6 +20,7 @@ class SparkJobService(ISparkJobService):
                  spark_job_namer,
                  storage_adapter,
                  validation_service):
+        self._bucket_name = 'kubernetes'
         self._kubernetes_adapter = kubernetes_adapter
         self._logger = logger
         self._manifest_populator = manifest_populator
@@ -212,10 +213,9 @@ class SparkJobService(ISparkJobService):
         if api_response['status'] != StatusCodes.Okay.value:
             return api_response
         try:
-            bucket_name = 'kubernetes'
             file_name = f'outputs/{job_name}/log.txt'
-            self._storage_adapter.set_contents_from_string(bucket_name, file_name, api_response['message'])
-            msg = f'Logs written to "{file_name}" in bucket "{bucket_name}"'
+            self._storage_adapter.set_contents_from_string(self._bucket_name, file_name, api_response['message'])
+            msg = f'Logs written to "{file_name}" in bucket "{self._bucket_name}"'
             self._logger.debug(msg)
             return {
                 'message': msg,
@@ -223,7 +223,7 @@ class SparkJobService(ISparkJobService):
             }
         except ApiException as exception:
             message = f'Got logs for job "{job_name}" but unable to write to "{file_name}" ' \
-                f'in bucket "{bucket_name}": {exception.reason}'
+                f'in bucket "{self._bucket_name}": {exception.reason}'
             self._logger.error(message)
             return {
                 'status': exception.status,

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -138,6 +138,12 @@ class SparkJobService(ISparkJobService):
                 'status': exception.status
             }
 
+    def get_output_files_temp_urls(self, job_name):
+        output_dir = self._job_output_dir_path(job_name)
+        temp_urls = self._storage_adapter.get_temp_url_for_each_file(self._bucket_name, output_dir)
+        self._logger.debug(f'Got temporary URLs for {len(temp_urls)} output files for job "{job_name}"')
+        return temp_urls
+
     def submit_job(self, body):
         # Validate the body keys
         validated_body_keys = self._validation_service.validate_request_keys(body)

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -192,7 +192,7 @@ class SparkJobService(ISparkJobService):
         dict_of_jobs = api_response['spark_jobs']
         loop = asyncio.get_event_loop()
         summary = loop.run_until_complete(asyncio.gather(*(
-            self.write_and_delete(job, status) for job, status in dict_of_jobs.items())))
+            self._write_and_delete(job, status) for job, status in dict_of_jobs.items())))
         jobs_skipped = {job.job_name: job.status for job in summary if job.tidied == "NO"}
         jobs_tidied = {job.job_name: job.status for job in summary if job.tidied == "YES"}
         jobs_failed_to_process = {
@@ -237,7 +237,7 @@ class SparkJobService(ISparkJobService):
         except KeyError:
             return 'UNKNOWN'
 
-    async def write_and_delete(self, job, status):
+    async def _write_and_delete(self, job, status):
         if status in ["COMPLETED", "FAILED"]:
             write_logs_response = self.write_logs_to_file(job)
             if write_logs_response['status'] == StatusCodes.Okay.value:

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -141,10 +141,12 @@ class SparkJobService(ISparkJobService):
     def get_output_files_temp_urls(self, job_name):
         output_dir = self._job_output_dir_path(job_name)
         temp_urls = self._storage_adapter.get_temp_url_for_each_file(self._bucket_name, output_dir)
-        self._logger.debug(f'Got temporary URLs for {len(temp_urls)} output files for job "{job_name}"')
+        msg = f'Got temporary URLs for {len(temp_urls)} output files for job "{job_name}"'
+        self._logger.debug(msg)
         status = StatusCodes.Okay if temp_urls else StatusCodes.Not_found
         return {
             'files': temp_urls,
+            'message': msg,
             'status': status.value
         }
 

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_job_service.py
@@ -213,7 +213,7 @@ class SparkJobService(ISparkJobService):
         if api_response['status'] != StatusCodes.Okay.value:
             return api_response
         try:
-            file_name = f'outputs/{job_name}/log.txt'
+            file_name = f'{self._job_output_dir_path(job_name)}/log.txt'
             self._storage_adapter.set_contents_from_string(self._bucket_name, file_name, api_response['message'])
             msg = f'Logs written to "{file_name}" in bucket "{self._bucket_name}"'
             self._logger.debug(msg)
@@ -229,6 +229,10 @@ class SparkJobService(ISparkJobService):
                 'status': exception.status,
                 'message': message
             }
+
+    @staticmethod
+    def _job_output_dir_path(job_name):
+        return f'outputs/{job_name}/'
 
     @staticmethod
     def _retrieve_status(item):

--- a/piezo_web_app/PiezoWebApp/src/services/storage/adapters/boto_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/storage/adapters/boto_adapter.py
@@ -26,6 +26,14 @@ class BotoAdapter(IStorageAdapter):
             self._logger.critical(exception)
             raise exception
 
+        self._temp_url_expiry_seconds = configuration.temp_url_expiry_seconds
+
+    def get_temp_url_for_each_file(self, bucket_name, file_prefix):
+        bucket = self._get_bucket(bucket_name)
+        keys = bucket.get_all_keys(prefix=file_prefix)
+        temp_urls = {key.name: key.generate_url(self._temp_url_expiry_seconds, method='GET') for key in keys}
+        return temp_urls
+
     def set_contents_from_string(self, bucket_name, file_path, text):
         key = self._get_key(bucket_name, file_path)
         contents_size = key.set_contents_from_string(text)

--- a/piezo_web_app/PiezoWebApp/src/services/storage/adapters/i_storage_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/storage/adapters/i_storage_adapter.py
@@ -4,5 +4,9 @@ from abc import ABCMeta, abstractmethod
 class IStorageAdapter(metaclass=ABCMeta):
 
     @abstractmethod
+    def get_temp_url_for_each_file(self, bucket_name, file_prefix):
+        pass
+
+    @abstractmethod
     def set_contents_from_string(self, bucket_name, file_path, text):
         pass

--- a/piezo_web_app/PiezoWebApp/src/utils/configurations.py
+++ b/piezo_web_app/PiezoWebApp/src/utils/configurations.py
@@ -29,6 +29,7 @@ class Configuration:
         self._s3_secrets_name = None
         self._secrets_dir = None
         self._is_s3_secure = None
+        self._temp_url_expiry_seconds = None
 
         self._parse(self._path_to_configuration_file)
 
@@ -83,6 +84,10 @@ class Configuration:
         parse_result = urlparse(self.s3_endpoint)
         return is_scheme_secure(parse_result.scheme)
 
+    @property
+    def temp_url_expiry_seconds(self):
+        return self._temp_url_expiry_seconds
+
     def _parse(self, path):
         config = configparser.ConfigParser()
         config.read(path)
@@ -104,6 +109,7 @@ class Configuration:
         self._s3_endpoint = storage['S3Endpoint']
         self._s3_secrets_name = storage['S3KeysSecret']
         self._secrets_dir = storage['SecretsDir']
+        self._temp_url_expiry_seconds = str2non_negative_int(storage['TempUrlExpirySeconds'])
 
     @staticmethod
     def get_directory(settings, key):

--- a/piezo_web_app/PiezoWebApp/tests/handlers/job_status_handler_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/job_status_handler_test.py
@@ -57,7 +57,6 @@ class TestJobStatusHandler(BaseHandlerTest):
                 "last_submitted": 123455,
                 "terminated": 1234567,
                 "error_messages": ""
-
             }
         })
 

--- a/piezo_web_app/PiezoWebApp/tests/handlers/output_files_handler_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/handlers/output_files_handler_test.py
@@ -1,0 +1,82 @@
+import json
+import pytest
+
+from mock import call
+from tornado.httpclient import HTTPError
+from tornado.testing import gen_test
+
+from PiezoWebApp.src.handlers.output_files_handler import OutputFilesHandler
+from PiezoWebApp.src.models.return_status import StatusCodes
+
+from PiezoWebApp.tests.handlers.base_handler_test import BaseHandlerTest
+
+
+class TestOutputFilesHandler(BaseHandlerTest):
+    @property
+    def handler(self):
+        return OutputFilesHandler
+
+    @property
+    def standard_request_method(self):
+        return 'GET'
+
+    @gen_test
+    def test_get_returns_400_when_job_name_is_missing(self):
+        body = {}
+        yield self.assert_request_returns_400(body)
+
+    @gen_test
+    def test_get_returns_urls_when_successful(self):
+        # Arrange
+        body = {'job_name': 'test-job-abc12'}
+        self.mock_spark_job_service.get_output_files_temp_urls.return_value = {
+            'status': StatusCodes.Okay.value,
+            'message': 'Got temporary URLs for 3 output files for job "test-job-abc12"',
+            'files': {
+                'log.txt': 's3://log.txt.temp.url',
+                'output1.csv': 's3://output1.csv.temp.url',
+                'output2.csv': 's3://output2.csv.temp.url'
+            }
+        }
+        # Act
+        response_body, response_code = yield self.send_request(body)
+        # Assert
+        self.mock_spark_job_service.get_output_files_temp_urls.assert_called_once_with('test-job-abc12')
+        self.mock_logger.debug.assert_has_calls([
+            call('Trying to get output files for spark job "test-job-abc12".'),
+            call('Getting output files for spark job "test-job-abc12" returned result "200".')
+        ])
+        assert response_code == 200
+        self.assertDictEqual(response_body, {
+            'status': 'success',
+            'data': {
+                'message': 'Got temporary URLs for 3 output files for job "test-job-abc12"',
+                'files': {
+                    'log.txt': 's3://log.txt.temp.url',
+                    'output1.csv': 's3://output1.csv.temp.url',
+                    'output2.csv': 's3://output2.csv.temp.url'
+                }
+            }
+        })
+
+    @gen_test
+    def test_get_returns_404_when_no_files_found(self):
+        # Arrange
+        body = {'job_name': 'test-job-abc12'}
+        self.mock_spark_job_service.get_output_files_temp_urls.return_value = {
+            'status': StatusCodes.Not_found.value,
+            'message': 'Got temporary URLs for 0 output files for job "test-job-abc12"',
+            'files': {}
+        }
+        # Act
+        with pytest.raises(HTTPError) as error:
+            yield self.send_request(body)
+        # Assert
+        self.mock_spark_job_service.get_output_files_temp_urls.assert_called_once_with('test-job-abc12')
+        self.mock_logger.debug.assert_has_calls([
+            call('Trying to get output files for spark job "test-job-abc12".'),
+            call('Getting output files for spark job "test-job-abc12" returned result "404".')
+        ])
+        assert error.value.response.code == 404
+        msg = json.loads(error.value.response.body, encoding='utf-8')['data']
+        assert msg == 'Got temporary URLs for 0 output files for job "test-job-abc12"'

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/output_files_integration_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/output_files_integration_test.py
@@ -23,9 +23,9 @@ class OutputFilesIntegrationTest(BaseIntegrationTest):
         # Arrange
         body = {'job_name': 'test-job-abc12'}
         self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {
-            'outputs/test-job-abc12/log.txt': 's3://log.txt.temp.url',
-            'outputs/test-job-abc12/output1.csv': 's3://output1.csv.temp.url',
-            'outputs/test-job-abc12/output2.csv': 's3://output2.csv.temp.url'
+            'outputs/test-job-abc12/log.txt': 'http://log.txt.temp.url',
+            'outputs/test-job-abc12/output1.csv': 'http://output1.csv.temp.url',
+            'outputs/test-job-abc12/output2.csv': 'http://output2.csv.temp.url'
         }
         # Act
         response_body, response_code = yield self.send_request(body)
@@ -38,9 +38,9 @@ class OutputFilesIntegrationTest(BaseIntegrationTest):
             'data': {
                 'message': 'Got temporary URLs for 3 output files for job "test-job-abc12"',
                 'files': {
-                    'log.txt': 's3://log.txt.temp.url',
-                    'output1.csv': 's3://output1.csv.temp.url',
-                    'output2.csv': 's3://output2.csv.temp.url'
+                    'log.txt': 'http://log.txt.temp.url',
+                    'output1.csv': 'http://output1.csv.temp.url',
+                    'output2.csv': 'http://output2.csv.temp.url'
                 }
             }
         })

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/output_files_integration_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/output_files_integration_test.py
@@ -1,0 +1,62 @@
+import json
+import pytest
+
+from mock import call
+from tornado.httpclient import HTTPError
+from tornado.testing import gen_test
+
+from PiezoWebApp.src.handlers.output_files_handler import OutputFilesHandler
+
+from PiezoWebApp.tests.integration_tests.base_integration_test import BaseIntegrationTest
+
+
+class OutputFilesIntegrationTest(BaseIntegrationTest):
+    @property
+    def handler(self):
+        return OutputFilesHandler
+
+    @property
+    def standard_request_method(self):
+        return 'GET'
+
+    @gen_test
+    def test_get_returns_urls_when_successful(self):
+        # Arrange
+        body = {'job_name': 'test-job-abc12'}
+        self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {
+            'log.txt': 's3://log.txt.temp.url',
+            'output1.csv': 's3://output1.csv.temp.url',
+            'output2.csv': 's3://output2.csv.temp.url'
+        }
+        # Act
+        response_body, response_code = yield self.send_request(body)
+        # Assert
+        self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
+            'kubernetes', 'outputs/test-job-abc12/')
+        assert response_code == 200
+        self.assertDictEqual(response_body, {
+            'status': 'success',
+            'data': {
+                'message': 'Got temporary URLs for 3 output files for job "test-job-abc12"',
+                'files': {
+                    'log.txt': 's3://log.txt.temp.url',
+                    'output1.csv': 's3://output1.csv.temp.url',
+                    'output2.csv': 's3://output2.csv.temp.url'
+                }
+            }
+        })
+
+    @gen_test
+    def test_get_returns_404_when_no_files_found(self):
+        # Arrange
+        body = {'job_name': 'test-job-abc12'}
+        self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {}
+        # Act
+        with pytest.raises(HTTPError) as error:
+            yield self.send_request(body)
+        # Assert
+        self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
+            'kubernetes', 'outputs/test-job-abc12/')
+        assert error.value.response.code == 404
+        msg = json.loads(error.value.response.body, encoding='utf-8')['data']
+        assert msg == 'Got temporary URLs for 0 output files for job "test-job-abc12"'

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/output_files_integration_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/output_files_integration_test.py
@@ -23,9 +23,9 @@ class OutputFilesIntegrationTest(BaseIntegrationTest):
         # Arrange
         body = {'job_name': 'test-job-abc12'}
         self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {
-            'log.txt': 's3://log.txt.temp.url',
-            'output1.csv': 's3://output1.csv.temp.url',
-            'output2.csv': 's3://output2.csv.temp.url'
+            'outputs/test-job-abc12/log.txt': 's3://log.txt.temp.url',
+            'outputs/test-job-abc12/output1.csv': 's3://output1.csv.temp.url',
+            'outputs/test-job-abc12/output2.csv': 's3://output2.csv.temp.url'
         }
         # Act
         response_body, response_code = yield self.send_request(body)

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/output_files_integration_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/output_files_integration_test.py
@@ -1,7 +1,6 @@
 import json
 import pytest
 
-from mock import call
 from tornado.httpclient import HTTPError
 from tornado.testing import gen_test
 

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_get_output_files_temp_urls_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_get_output_files_temp_urls_test.py
@@ -1,0 +1,52 @@
+from PiezoWebApp.tests.services.spark_job.spark_job_service_test import TestSparkJobService
+
+
+class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
+    def test_get_output_files_temp_urls_returns_single_file_temp_url(self):
+        # Arrange
+        self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {
+            'log.txt': 's3://log.txt.temp.url'
+        }
+        # Act
+        result = self.test_service.get_output_files_temp_urls('test-job-abc12')
+        # Assert
+        self.assertDictEqual(result, {'log.txt': 's3://log.txt.temp.url'})
+        self.mock_logger.debug.assert_called_once_with('Got temporary URLs for 1 output files for job "test-job-abc12"')
+        self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
+            'kubernetes',
+            'outputs/test-job-abc12/'
+        )
+
+    def test_get_output_files_temp_urls_returns_empty_dictionary_when_no_files(self):
+        # Arrange
+        self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {}
+        # Act
+        result = self.test_service.get_output_files_temp_urls('test-job-abc12')
+        # Assert
+        self.assertDictEqual(result, {})
+        self.mock_logger.debug.assert_called_once_with('Got temporary URLs for 0 output files for job "test-job-abc12"')
+        self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
+            'kubernetes',
+            'outputs/test-job-abc12/'
+        )
+
+    def test_get_output_files_temp_urls_returns_multiple_files_temp_urls(self):
+        # Arrange
+        self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {
+            'log.txt': 's3://log.txt.temp.url',
+            'output1.csv': 's3://output1.csv.temp.url',
+            'output2.csv': 's3://output2.csv.temp.url'
+        }
+        # Act
+        result = self.test_service.get_output_files_temp_urls('test-job-abc12')
+        # Assert
+        self.assertDictEqual(result, {
+            'log.txt': 's3://log.txt.temp.url',
+            'output1.csv': 's3://output1.csv.temp.url',
+            'output2.csv': 's3://output2.csv.temp.url'
+        })
+        self.mock_logger.debug.assert_called_once_with('Got temporary URLs for 3 output files for job "test-job-abc12"')
+        self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
+            'kubernetes',
+            'outputs/test-job-abc12/'
+        )

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_get_output_files_temp_urls_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_get_output_files_temp_urls_test.py
@@ -12,6 +12,7 @@ class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
         # Assert
         self.assertDictEqual(result, {
             'status': 200,
+            'message': 'Got temporary URLs for 1 output files for job "test-job-abc12"',
             'files': {'log.txt': 's3://log.txt.temp.url'}
         })
         self.mock_logger.debug.assert_called_once_with('Got temporary URLs for 1 output files for job "test-job-abc12"')
@@ -26,7 +27,11 @@ class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
         # Act
         result = self.test_service.get_output_files_temp_urls('test-job-abc12')
         # Assert
-        self.assertDictEqual(result, {'status': 404, 'files': {}})
+        self.assertDictEqual(result, {
+            'status': 404,
+            'message': 'Got temporary URLs for 0 output files for job "test-job-abc12"',
+            'files': {}
+        })
         self.mock_logger.debug.assert_called_once_with('Got temporary URLs for 0 output files for job "test-job-abc12"')
         self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
             'kubernetes',
@@ -45,6 +50,7 @@ class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
         # Assert
         self.assertDictEqual(result, {
             'status': 200,
+            'message': 'Got temporary URLs for 3 output files for job "test-job-abc12"',
             'files': {
                 'log.txt': 's3://log.txt.temp.url',
                 'output1.csv': 's3://output1.csv.temp.url',

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_get_output_files_temp_urls_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_get_output_files_temp_urls_test.py
@@ -10,7 +10,10 @@ class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
         # Act
         result = self.test_service.get_output_files_temp_urls('test-job-abc12')
         # Assert
-        self.assertDictEqual(result, {'log.txt': 's3://log.txt.temp.url'})
+        self.assertDictEqual(result, {
+            'status': 200,
+            'files': {'log.txt': 's3://log.txt.temp.url'}
+        })
         self.mock_logger.debug.assert_called_once_with('Got temporary URLs for 1 output files for job "test-job-abc12"')
         self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
             'kubernetes',
@@ -23,7 +26,7 @@ class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
         # Act
         result = self.test_service.get_output_files_temp_urls('test-job-abc12')
         # Assert
-        self.assertDictEqual(result, {})
+        self.assertDictEqual(result, {'status': 404, 'files': {}})
         self.mock_logger.debug.assert_called_once_with('Got temporary URLs for 0 output files for job "test-job-abc12"')
         self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
             'kubernetes',
@@ -41,9 +44,12 @@ class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
         result = self.test_service.get_output_files_temp_urls('test-job-abc12')
         # Assert
         self.assertDictEqual(result, {
-            'log.txt': 's3://log.txt.temp.url',
-            'output1.csv': 's3://output1.csv.temp.url',
-            'output2.csv': 's3://output2.csv.temp.url'
+            'status': 200,
+            'files': {
+                'log.txt': 's3://log.txt.temp.url',
+                'output1.csv': 's3://output1.csv.temp.url',
+                'output2.csv': 's3://output2.csv.temp.url'
+            }
         })
         self.mock_logger.debug.assert_called_once_with('Got temporary URLs for 3 output files for job "test-job-abc12"')
         self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_get_output_files_temp_urls_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_get_output_files_temp_urls_test.py
@@ -5,7 +5,7 @@ class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
     def test_get_output_files_temp_urls_returns_single_file_temp_url(self):
         # Arrange
         self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {
-            'log.txt': 's3://log.txt.temp.url'
+            'outputs/test-job-abc12/log.txt': 'http://log.txt.temp.url'
         }
         # Act
         result = self.test_service.get_output_files_temp_urls('test-job-abc12')
@@ -13,7 +13,7 @@ class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
         self.assertDictEqual(result, {
             'status': 200,
             'message': 'Got temporary URLs for 1 output files for job "test-job-abc12"',
-            'files': {'log.txt': 's3://log.txt.temp.url'}
+            'files': {'log.txt': 'http://log.txt.temp.url'}
         })
         self.mock_logger.debug.assert_called_once_with('Got temporary URLs for 1 output files for job "test-job-abc12"')
         self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
@@ -41,9 +41,9 @@ class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
     def test_get_output_files_temp_urls_returns_multiple_files_temp_urls(self):
         # Arrange
         self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {
-            'log.txt': 's3://log.txt.temp.url',
-            'output1.csv': 's3://output1.csv.temp.url',
-            'output2.csv': 's3://output2.csv.temp.url'
+            'outputs/test-job-abc12/log.txt': 'http://log.txt.temp.url',
+            'outputs/test-job-abc12/output1.csv': 'http://output1.csv.temp.url',
+            'outputs/test-job-abc12/output2.csv': 'http://output2.csv.temp.url'
         }
         # Act
         result = self.test_service.get_output_files_temp_urls('test-job-abc12')
@@ -52,9 +52,9 @@ class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
             'status': 200,
             'message': 'Got temporary URLs for 3 output files for job "test-job-abc12"',
             'files': {
-                'log.txt': 's3://log.txt.temp.url',
-                'output1.csv': 's3://output1.csv.temp.url',
-                'output2.csv': 's3://output2.csv.temp.url'
+                'log.txt': 'http://log.txt.temp.url',
+                'output1.csv': 'http://output1.csv.temp.url',
+                'output2.csv': 'http://output2.csv.temp.url'
             }
         })
         self.mock_logger.debug.assert_called_once_with('Got temporary URLs for 3 output files for job "test-job-abc12"')

--- a/piezo_web_app/PiezoWebApp/tests/utils/configuration_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/utils/configuration_test.py
@@ -17,7 +17,8 @@ class SampleConfigurationCreator:
                              tidy_frequency,
                              s3_endpoint,
                              s3_secret_name,
-                             secrets_dir):
+                             secrets_dir,
+                             temp_url_expiry_seconds):
         template = "[Logging]\n"
         template = SampleConfigurationCreator.add_element_to_temp_file(template,
                                                                        "LogFolderLocation",
@@ -48,6 +49,9 @@ class SampleConfigurationCreator:
         template = SampleConfigurationCreator.add_element_to_temp_file(template,
                                                                        "SecretsDir",
                                                                        secrets_dir)
+        template = SampleConfigurationCreator.add_element_to_temp_file(template,
+                                                                       "TempUrlExpirySeconds",
+                                                                       temp_url_expiry_seconds)
 
         return SampleConfigurationCreator.write_sample_configuration_file(template)
 
@@ -90,7 +94,8 @@ def test_configuration_parses_with_arguments():
                                                                          "3600",
                                                                          "https://0.0.0.0:0",
                                                                          "some_secret",
-                                                                         "/etc/secrets/")
+                                                                         "/etc/secrets/",
+                                                                         "600")
 
     # Act
     configuration = Configuration(configuration_path)
@@ -108,6 +113,7 @@ def test_configuration_parses_with_arguments():
     assert configuration.s3_secrets_name == "some_secret"
     assert configuration.secrets_dir == "/etc/secrets/"
     assert configuration.is_s3_secure is True
+    assert configuration.temp_url_expiry_seconds == 600
 
     # Clean up
     SampleConfigurationCreator.remove_file(configuration_path)


### PR DESCRIPTION
Stories covered: https://github.com/ukaea/piezo/issues/112

In the course of developing this feature, another task was opened: https://github.com/ukaea/piezo/issues/111

When this is completed, the new system test should be modified to make just one call to the `outputfiles` handler.