### PR TITLE
Feature/make s3 bucket name configurable#115

### DIFF
--- a/piezo_web_app/PiezoWebApp/example_configuration.ini
+++ b/piezo_web_app/PiezoWebApp/example_configuration.ini
@@ -10,6 +10,7 @@ TidyFrequency = 3600
 
 [Storage]
 S3Endpoint = URL_OF_S3
+S3BucketName = NAME_OF_DESIGNATED_BUCKET
 S3KeysSecret = NAME_OF_SECRET_CONTAINING_S3_KEYS
 SecretsDir = /etc/secrets/
 TempUrlExpirySeconds = 600

--- a/piezo_web_app/PiezoWebApp/run_piezo.py
+++ b/piezo_web_app/PiezoWebApp/run_piezo.py
@@ -22,6 +22,7 @@ from PiezoWebApp.src.services.spark_job.spark_job_service import SparkJobService
 from PiezoWebApp.src.services.spark_job.validation.manifest_populator import ManifestPopulator
 from PiezoWebApp.src.services.spark_job.validation.validation_ruleset import ValidationRuleset
 from PiezoWebApp.src.services.spark_job.validation.validation_service import ValidationService
+from PiezoWebApp.src.services.storage.storage_service import StorageService
 from PiezoWebApp.src.services.storage.adapters.boto_adapter import BotoAdapter
 from PiezoWebApp.src.utils.configurations import Configuration
 from PiezoWebApp.src.utils.route_helper import format_route_specification
@@ -60,6 +61,7 @@ def build_logger(configuration):
 
 
 def build_container(configuration, k8s_adapter, log, storage_adapter, validation_rules_path):
+    storage_service = StorageService(configuration, log, storage_adapter)
     validation_rules = ValidationRulesetParser().parse(validation_rules_path)
     validation_ruleset = ValidationRuleset(validation_rules)
     validation_service = ValidationService(validation_ruleset)
@@ -70,7 +72,7 @@ def build_container(configuration, k8s_adapter, log, storage_adapter, validation
         log,
         manifest_populator,
         spark_job_namer,
-        storage_adapter,
+        storage_service,
         validation_service
     )
     container = dict(

--- a/piezo_web_app/PiezoWebApp/run_piezo.py
+++ b/piezo_web_app/PiezoWebApp/run_piezo.py
@@ -40,9 +40,10 @@ def build_kubernetes_adapter(configuration):
     return adapter
 
 
-def build_storage_adapter(configuration):
+def build_storage_adapter(configuration, logger):
     with open(os.path.join(configuration.secrets_dir, 'access_key')) as key_file:
         access_key = key_file.read()
+    logger.info(f'Using storage access key "{access_key}"')
     with open(os.path.join(configuration.secrets_dir, 'secret_key')) as key_file:
         secret_key = key_file.read()
     storage_adapter = BotoAdapter(
@@ -134,7 +135,7 @@ if __name__ == "__main__":
         os.path.abspath(os.path.join(os.path.dirname(__file__), 'validation_rules.json'))
     KUBERNETES_ADAPTER = build_kubernetes_adapter(CONFIGURATION)
     LOGGER = build_logger(CONFIGURATION)
-    STORAGE_ADAPTER = build_storage_adapter(CONFIGURATION)
+    STORAGE_ADAPTER = build_storage_adapter(CONFIGURATION, LOGGER)
     CONTAINER = build_container(CONFIGURATION, KUBERNETES_ADAPTER, LOGGER, STORAGE_ADAPTER, VALIDATION_RULES_PATH)
     APPLICATION = build_app(CONTAINER, use_route_stem=True)
     APPLICATION.listen(CONFIGURATION.app_port)

--- a/piezo_web_app/PiezoWebApp/run_piezo.py
+++ b/piezo_web_app/PiezoWebApp/run_piezo.py
@@ -41,12 +41,16 @@ def build_kubernetes_adapter(configuration):
 
 
 def build_storage_adapter(configuration):
+    with open(os.path.join(configuration.secrets_dir, 'access_key')) as key_file:
+        access_key = key_file.read()
+    with open(os.path.join(configuration.secrets_dir, 'secret_key')) as key_file:
+        secret_key = key_file.read()
     storage_adapter = BotoAdapter(
-        configuration.access_key,
+        access_key,
         configuration.is_s3_secure,
         configuration.s3_host,
         configuration.s3_port,
-        configuration.secret_key
+        secret_key
     )
     return storage_adapter
 

--- a/piezo_web_app/PiezoWebApp/run_piezo.py
+++ b/piezo_web_app/PiezoWebApp/run_piezo.py
@@ -40,6 +40,17 @@ def build_kubernetes_adapter(configuration):
     return adapter
 
 
+def build_storage_adapter(configuration):
+    storage_adapter = BotoAdapter(
+        configuration.access_key,
+        configuration.is_s3_secure,
+        configuration.s3_host,
+        configuration.s3_port,
+        configuration.secret_key
+    )
+    return storage_adapter
+
+
 def build_logger(configuration):
     # Set  up the logger
     log = logging.getLogger("piezo-web-app")
@@ -119,7 +130,7 @@ if __name__ == "__main__":
         os.path.abspath(os.path.join(os.path.dirname(__file__), 'validation_rules.json'))
     KUBERNETES_ADAPTER = build_kubernetes_adapter(CONFIGURATION)
     LOGGER = build_logger(CONFIGURATION)
-    STORAGE_ADAPTER = BotoAdapter(CONFIGURATION, LOGGER)
+    STORAGE_ADAPTER = build_storage_adapter(CONFIGURATION)
     CONTAINER = build_container(CONFIGURATION, KUBERNETES_ADAPTER, LOGGER, STORAGE_ADAPTER, VALIDATION_RULES_PATH)
     APPLICATION = build_app(CONTAINER, use_route_stem=True)
     APPLICATION.listen(CONFIGURATION.app_port)

--- a/piezo_web_app/PiezoWebApp/src/services/storage/adapters/boto_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/storage/adapters/boto_adapter.py
@@ -8,30 +8,10 @@ from PiezoWebApp.src.services.storage.adapters.i_storage_adapter import IStorage
 class BotoAdapter(IStorageAdapter):
     def __init__(self, configuration, logger):
         self._logger = logger
-
-        with open(os.path.join(configuration.secrets_dir, 'access_key')) as key_file:
-            access_key = key_file.read()
-        with open(os.path.join(configuration.secrets_dir, 'secret_key')) as key_file:
-            secret_key = key_file.read()
-        try:
-            self._s3_client = boto.connect_s3(
-                aws_access_key_id=access_key,
-                aws_secret_access_key=secret_key,
-                host=configuration.s3_host,
-                port=configuration.s3_port,
-                is_secure=configuration.is_s3_secure,
-                calling_format=boto.s3.connection.OrdinaryCallingFormat()
-            )
-        except Exception as exception:
-            self._logger.critical(exception)
-            raise exception
-
-        bucket_name = configuration.s3_self.s3_bucket_name
-        self._bucket = self._s3_client.lookup(bucket_name)
-        if self._bucket is None:
-            self._bucket = self._s3_client.create_bucket(bucket_name, location="")
-
         self._temp_url_expiry_seconds = configuration.temp_url_expiry_seconds
+
+        self._s3_client = self._get_client(configuration)
+        self._bucket = self._get_bucket(configuration.s3_bucket_name, self._s3_client)
 
     def get_temp_url_for_each_file(self, bucket_name, file_prefix):
         keys = self._bucket.get_all_keys(prefix=file_prefix)
@@ -42,6 +22,34 @@ class BotoAdapter(IStorageAdapter):
         key = self._get_key(file_path)
         contents_size = key.set_contents_from_string(text)
         self._logger.debug(f'Wrote {contents_size} bytes to "{file_path}" in bucket "{bucket_name}"')
+
+    def _get_bucket(self, bucket_name, client):
+        try:
+            bucket = client.lookup(bucket_name)
+            if bucket is None:
+                bucket = client.create_bucket(bucket_name, location="")
+            return bucket
+        except Exception as exception:
+            self._logger.critical(exception)
+            raise exception
+
+    def _get_client(self, configuration):
+        with open(os.path.join(configuration.secrets_dir, 'access_key')) as key_file:
+            access_key = key_file.read()
+        with open(os.path.join(configuration.secrets_dir, 'secret_key')) as key_file:
+            secret_key = key_file.read()
+        try:
+            return boto.connect_s3(
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                host=configuration.s3_host,
+                port=configuration.s3_port,
+                is_secure=configuration.is_s3_secure,
+                calling_format=boto.s3.connection.OrdinaryCallingFormat()
+            )
+        except Exception as exception:
+            self._logger.critical(exception)
+            raise exception
 
     def _get_key(self, file_path):
         key = self._bucket.get_key(file_path)

--- a/piezo_web_app/PiezoWebApp/src/services/storage/adapters/boto_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/storage/adapters/boto_adapter.py
@@ -26,28 +26,25 @@ class BotoAdapter(IStorageAdapter):
             self._logger.critical(exception)
             raise exception
 
+        bucket_name = configuration.s3_self.s3_bucket_name
+        self._bucket = self._s3_client.lookup(bucket_name)
+        if self._bucket is None:
+            self._bucket = self._s3_client.create_bucket(bucket_name, location="")
+
         self._temp_url_expiry_seconds = configuration.temp_url_expiry_seconds
 
     def get_temp_url_for_each_file(self, bucket_name, file_prefix):
-        bucket = self._get_bucket(bucket_name)
-        keys = bucket.get_all_keys(prefix=file_prefix)
+        keys = self._bucket.get_all_keys(prefix=file_prefix)
         temp_urls = {key.name: key.generate_url(self._temp_url_expiry_seconds, method='GET') for key in keys}
         return temp_urls
 
     def set_contents_from_string(self, bucket_name, file_path, text):
-        key = self._get_key(bucket_name, file_path)
+        key = self._get_key(file_path)
         contents_size = key.set_contents_from_string(text)
         self._logger.debug(f'Wrote {contents_size} bytes to "{file_path}" in bucket "{bucket_name}"')
 
-    def _get_bucket(self, bucket_name):
-        bucket = self._s3_client.lookup(bucket_name)
-        if bucket is None:
-            raise RuntimeError(f'Bucket "{bucket_name}" does not exist')
-        return bucket
-
-    def _get_key(self, bucket_name, file_path):
-        bucket = self._get_bucket(bucket_name)
-        key = bucket.get_key(file_path)
+    def _get_key(self, file_path):
+        key = self._bucket.get_key(file_path)
         if key is None:
-            key = bucket.new_key(file_path)
+            key = self._bucket.new_key(file_path)
         return key

--- a/piezo_web_app/PiezoWebApp/src/services/storage/adapters/boto_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/storage/adapters/boto_adapter.py
@@ -34,6 +34,7 @@ class BotoAdapter(IStorageAdapter):
         return files
 
     def set_contents_from_string(self, bucket_name, file_path, text):
+        bucket = self._get_bucket(bucket_name)
         key = self._get_key(bucket, file_path)
         contents_size = key.set_contents_from_string(text)
         return contents_size

--- a/piezo_web_app/PiezoWebApp/src/services/storage/adapters/boto_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/storage/adapters/boto_adapter.py
@@ -1,55 +1,46 @@
-import os.path
-
 import boto.s3.connection
 
 from PiezoWebApp.src.services.storage.adapters.i_storage_adapter import IStorageAdapter
 
 
 class BotoAdapter(IStorageAdapter):
-    def __init__(self, configuration, logger):
-        self._logger = logger
-        self._temp_url_expiry_seconds = configuration.temp_url_expiry_seconds
+    def __init__(self, access_key, is_s3_secure, s3_host, s3_port, secret_key):
+        self._s3_client = boto.connect_s3(
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                host=s3_host,
+                port=s3_port,
+                is_secure=is_s3_secure,
+                calling_format=boto.s3.connection.OrdinaryCallingFormat()
+            )
 
-        self._s3_client = self._get_client(configuration)
-        self._bucket = self._get_bucket(configuration.s3_bucket_name, self._s3_client)
+    def create_bucket(self, bucket_name):
+        self._s3_client.create_bucket(bucket_name, location="")
 
-    def get_temp_url_for_each_file(self, bucket_name, file_prefix):
-        keys = self._bucket.get_all_keys(prefix=file_prefix)
-        temp_urls = {key.name: key.generate_url(self._temp_url_expiry_seconds, method='GET') for key in keys}
-        return temp_urls
+    def does_bucket_exist(self, bucket_name):
+        bucket = self._s3_client.lookup(bucket_name)
+        return bucket is not None
+
+    def generate_temp_url(self, bucket_name, file_path, expiry_seconds, method):
+        bucket = self._get_bucket(bucket_name)
+        key = bucket.get_key(file_path)
+        temp_url = key.generate_url(expiry_seconds, method=method)
+        return temp_url
+
+    def get_all_files(self, bucket_name, file_prefix):
+        bucket = self._get_bucket(bucket_name)
+        keys = bucket.get_all_keys(prefix=file_prefix)
+        files = [key.name for key in keys]
+        return files
 
     def set_contents_from_string(self, bucket_name, file_path, text):
         key = self._get_key(file_path)
         contents_size = key.set_contents_from_string(text)
-        self._logger.debug(f'Wrote {contents_size} bytes to "{file_path}" in bucket "{bucket_name}"')
+        return contents_size
 
-    def _get_bucket(self, bucket_name, client):
-        try:
-            bucket = client.lookup(bucket_name)
-            if bucket is None:
-                bucket = client.create_bucket(bucket_name, location="")
-            return bucket
-        except Exception as exception:
-            self._logger.critical(exception)
-            raise exception
-
-    def _get_client(self, configuration):
-        with open(os.path.join(configuration.secrets_dir, 'access_key')) as key_file:
-            access_key = key_file.read()
-        with open(os.path.join(configuration.secrets_dir, 'secret_key')) as key_file:
-            secret_key = key_file.read()
-        try:
-            return boto.connect_s3(
-                aws_access_key_id=access_key,
-                aws_secret_access_key=secret_key,
-                host=configuration.s3_host,
-                port=configuration.s3_port,
-                is_secure=configuration.is_s3_secure,
-                calling_format=boto.s3.connection.OrdinaryCallingFormat()
-            )
-        except Exception as exception:
-            self._logger.critical(exception)
-            raise exception
+    def _get_bucket(self, bucket_name):
+        bucket = self._s3_client.lookup(bucket_name)
+        return bucket
 
     def _get_key(self, file_path):
         key = self._bucket.get_key(file_path)

--- a/piezo_web_app/PiezoWebApp/src/services/storage/adapters/boto_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/storage/adapters/boto_adapter.py
@@ -34,7 +34,7 @@ class BotoAdapter(IStorageAdapter):
         return files
 
     def set_contents_from_string(self, bucket_name, file_path, text):
-        key = self._get_key(file_path)
+        key = self._get_key(bucket, file_path)
         contents_size = key.set_contents_from_string(text)
         return contents_size
 
@@ -42,8 +42,9 @@ class BotoAdapter(IStorageAdapter):
         bucket = self._s3_client.lookup(bucket_name)
         return bucket
 
-    def _get_key(self, file_path):
-        key = self._bucket.get_key(file_path)
+    @staticmethod
+    def _get_key(bucket, file_path):
+        key = bucket.get_key(file_path)
         if key is None:
-            key = self._bucket.new_key(file_path)
+            key = bucket.new_key(file_path)
         return key

--- a/piezo_web_app/PiezoWebApp/src/services/storage/adapters/i_storage_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/storage/adapters/i_storage_adapter.py
@@ -4,7 +4,19 @@ from abc import ABCMeta, abstractmethod
 class IStorageAdapter(metaclass=ABCMeta):
 
     @abstractmethod
-    def get_temp_url_for_each_file(self, bucket_name, file_prefix):
+    def create_bucket(self, bucket_name):
+        pass
+
+    @abstractmethod
+    def does_bucket_exist(self, bucket_name):
+        pass
+
+    @abstractmethod
+    def generate_temp_url(self, bucket_name, file_path, expiry_seconds, method):
+        pass
+
+    @abstractmethod
+    def get_all_files(self, bucket_name, file_prefix):
         pass
 
     @abstractmethod

--- a/piezo_web_app/PiezoWebApp/src/services/storage/i_storage_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/storage/i_storage_service.py
@@ -1,0 +1,12 @@
+from abc import ABCMeta, abstractmethod
+
+
+class IStorageService(metaclass=ABCMeta):
+
+    @abstractmethod
+    def get_temp_url_for_each_file(self, file_prefix):
+        pass
+
+    @abstractmethod
+    def set_contents_from_string(self, file_path, text):
+        pass

--- a/piezo_web_app/PiezoWebApp/src/services/storage/storage_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/storage/storage_service.py
@@ -1,0 +1,33 @@
+from PiezoWebApp.src.services.storage.i_storage_service import IStorageService
+
+
+class StorageService(IStorageService):
+    def __init__(self, configuration, logger, storage_adapter):
+        self._bucket_name = configuration.s3_bucket_name
+        self._temp_url_expiry_seconds = configuration.temp_url_expiry_seconds
+        self._logger = logger
+        self._storage_adapter = storage_adapter
+
+        self._set_up_bucket(self._bucket_name)
+
+    def get_temp_url_for_each_file(self, file_prefix):
+        files = self._storage_adapter.get_all_files(self._bucket_name, file_prefix)
+        urls = {
+            file_path: self._storage_adapter.generate_temp_url(
+                self._bucket_name, file_path, self._temp_url_expiry_seconds, 'GET'
+            )
+            for file_path in files
+        }
+        self._logger.debug(f'Generated temporary GET URLs for {len(files)} files in "{file_prefix}"')
+        return urls
+
+    def set_contents_from_string(self, file_path, text):
+        contents_size = self._storage_adapter.set_contents_from_string(self._bucket_name, file_path, text)
+        self._logger.debug(f'Wrote {contents_size} bytes to "{file_path}"')
+
+    def _set_up_bucket(self, bucket_name):
+        if self._storage_adapter.does_bucket_exist(bucket_name):
+            self._logger.info(f'Bucket "{bucket_name}" already exists: no need to change')
+        else:
+            self._storage_adapter.create_bucket(bucket_name)
+            self._logger.info(f'Created new bucket "{bucket_name}"')

--- a/piezo_web_app/PiezoWebApp/src/utils/configurations.py
+++ b/piezo_web_app/PiezoWebApp/src/utils/configurations.py
@@ -26,6 +26,7 @@ class Configuration:
 
         # Storage
         self._s3_endpoint = None
+        self._s3_bucket_name = None
         self._s3_secrets_name = None
         self._secrets_dir = None
         self._is_s3_secure = None
@@ -72,6 +73,10 @@ class Configuration:
         return parse_result.port
 
     @property
+    def s3_bucket_name(self):
+        return self._s3_bucket_name
+
+    @property
     def s3_secrets_name(self):
         return self._s3_secrets_name
 
@@ -107,6 +112,7 @@ class Configuration:
 
         # Storage
         self._s3_endpoint = storage['S3Endpoint']
+        self._s3_bucket_name = storage['S3BucketName']
         self._s3_secrets_name = storage['S3KeysSecret']
         self._secrets_dir = storage['SecretsDir']
         self._temp_url_expiry_seconds = str2non_negative_int(storage['TempUrlExpirySeconds'])

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/base_integration_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/base_integration_test.py
@@ -40,11 +40,14 @@ class BaseIntegrationTest(tornado.testing.AsyncHTTPTestCase, metaclass=ABCMeta):
     def setup(self):
         self.mock_configuration = mock.create_autospec(Configuration)
         self.mock_configuration.s3_endpoint = "http://0.0.0.0:0"
+        self.mock_configuration.s3_bucket_name = 'kubernetes'
         self.mock_configuration.s3_secrets_name = "secret"
         self.mock_configuration.secrets_dir = "/etc/secrets/"
+        self.mock_configuration.temp_url_expiry_seconds = 10
         self.mock_k8s_adapter = mock.create_autospec(IKubernetesAdapter)
         self.mock_logger = mock.create_autospec(logging.Logger)
         self.mock_storage_adapter = mock.create_autospec(IStorageAdapter)
+        self.mock_storage_adapter.does_bucket_exist.return_value = True
         self.ruleset_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'example_validation_rules.json'))
 
     def get_app(self):

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/output_files_integration_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/output_files_integration_test.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 
+from mock import call
 from tornado.httpclient import HTTPError
 from tornado.testing import gen_test
 
@@ -22,16 +23,25 @@ class OutputFilesIntegrationTest(BaseIntegrationTest):
     def test_get_returns_urls_when_successful(self):
         # Arrange
         body = {'job_name': 'test-job-abc12'}
-        self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {
-            'outputs/test-job-abc12/log.txt': 'http://log.txt.temp.url',
-            'outputs/test-job-abc12/output1.csv': 'http://output1.csv.temp.url',
-            'outputs/test-job-abc12/output2.csv': 'http://output2.csv.temp.url'
-        }
+        self.mock_storage_adapter.get_all_files.return_value = [
+            'outputs/test-job-abc12/log.txt',
+            'outputs/test-job-abc12/output1.csv',
+            'outputs/test-job-abc12/output2.csv'
+        ]
+        self.mock_storage_adapter.generate_temp_url.side_effect = [
+            'http://log.txt.temp.url',
+            'http://output1.csv.temp.url',
+            'http://output2.csv.temp.url'
+        ]
         # Act
         response_body, response_code = yield self.send_request(body)
         # Assert
-        self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
-            'kubernetes', 'outputs/test-job-abc12/')
+        self.mock_storage_adapter.get_all_files.assert_called_once_with('kubernetes', 'outputs/test-job-abc12/')
+        self.mock_storage_adapter.generate_temp_url.assert_has_calls([
+            call('kubernetes', 'outputs/test-job-abc12/log.txt', 10, 'GET'),
+            call('kubernetes', 'outputs/test-job-abc12/output1.csv', 10, 'GET'),
+            call('kubernetes', 'outputs/test-job-abc12/output2.csv', 10, 'GET')
+        ])
         assert response_code == 200
         self.assertDictEqual(response_body, {
             'status': 'success',
@@ -49,13 +59,13 @@ class OutputFilesIntegrationTest(BaseIntegrationTest):
     def test_get_returns_404_when_no_files_found(self):
         # Arrange
         body = {'job_name': 'test-job-abc12'}
-        self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {}
+        self.mock_storage_adapter.get_all_files.return_value = []
         # Act
         with pytest.raises(HTTPError) as error:
             yield self.send_request(body)
         # Assert
-        self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
-            'kubernetes', 'outputs/test-job-abc12/')
+        self.mock_storage_adapter.get_all_files.assert_called_once_with('kubernetes', 'outputs/test-job-abc12/')
+        self.mock_storage_adapter.generate_temp_url.assert_not_called()
         assert error.value.response.code == 404
         msg = json.loads(error.value.response.body, encoding='utf-8')['data']
         assert msg == 'Got temporary URLs for 0 output files for job "test-job-abc12"'

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/tidy_jobs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/tidy_jobs_test.py
@@ -112,9 +112,9 @@ class TestTidyJobsIntegration(BaseIntegrationTest):
         assert self.mock_k8s_adapter.delete_namespaced_custom_object.call_count == 2
         assert response_code == 200
         self.mock_logger.debug.assert_any_call('Not processing job "job1", current status is "RUNNING"')
-        self.mock_logger.debug.assert_any_call('Logs written to "outputs/job2/log.txt" in bucket "kubernetes"')
+        self.mock_logger.debug.assert_any_call('Logs written to "outputs/job2/log.txt"')
         self.mock_logger.debug.assert_any_call('Trying to delete job "job2" resulted in status: 200')
-        self.mock_logger.debug.assert_any_call('Logs written to "outputs/job3/log.txt" in bucket "kubernetes"')
+        self.mock_logger.debug.assert_any_call('Logs written to "outputs/job3/log.txt"')
         self.mock_logger.debug.assert_any_call('Trying to delete job "job3" resulted in status: 200')
         self.assertDictEqual(response_body, {
             'status': 'success',

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/write_logs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/write_logs_test.py
@@ -24,6 +24,7 @@ class TestWriteLogsToFileIntegration(BaseIntegrationTest):
         # Arrange
         body = {'job_name': 'test-job'}
         self.mock_k8s_adapter.read_namespaced_pod_log.return_value = 'Log\nFile\nContent'
+        self.mock_storage_adapter.set_contents_from_string.return_value = 12345
         # Act
         response_body, response_code = yield self.send_request(body)
         # Assert
@@ -33,7 +34,7 @@ class TestWriteLogsToFileIntegration(BaseIntegrationTest):
         assert response_code == 200
         self.assertDictEqual(response_body, {
             'status': 'success',
-            'data': {'message': 'Logs written to "outputs/test-job/log.txt" in bucket "kubernetes"'}
+            'data': {'message': 'Logs written to "outputs/test-job/log.txt"'}
         })
 
     @gen_test

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_get_output_files_temp_urls_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_get_output_files_temp_urls_test.py
@@ -4,7 +4,7 @@ from PiezoWebApp.tests.services.spark_job.spark_job_service_test import TestSpar
 class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
     def test_get_output_files_temp_urls_returns_single_file_temp_url(self):
         # Arrange
-        self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {
+        self.mock_storage_service.get_temp_url_for_each_file.return_value = {
             'outputs/test-job-abc12/log.txt': 'http://log.txt.temp.url'
         }
         # Act
@@ -16,14 +16,13 @@ class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
             'files': {'log.txt': 'http://log.txt.temp.url'}
         })
         self.mock_logger.debug.assert_called_once_with('Got temporary URLs for 1 output files for job "test-job-abc12"')
-        self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
-            'kubernetes',
+        self.mock_storage_service.get_temp_url_for_each_file.assert_called_once_with(
             'outputs/test-job-abc12/'
         )
 
     def test_get_output_files_temp_urls_returns_empty_dictionary_when_no_files(self):
         # Arrange
-        self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {}
+        self.mock_storage_service.get_temp_url_for_each_file.return_value = {}
         # Act
         result = self.test_service.get_output_files_temp_urls('test-job-abc12')
         # Assert
@@ -33,14 +32,13 @@ class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
             'files': {}
         })
         self.mock_logger.debug.assert_called_once_with('Got temporary URLs for 0 output files for job "test-job-abc12"')
-        self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
-            'kubernetes',
+        self.mock_storage_service.get_temp_url_for_each_file.assert_called_once_with(
             'outputs/test-job-abc12/'
         )
 
     def test_get_output_files_temp_urls_returns_multiple_files_temp_urls(self):
         # Arrange
-        self.mock_storage_adapter.get_temp_url_for_each_file.return_value = {
+        self.mock_storage_service.get_temp_url_for_each_file.return_value = {
             'outputs/test-job-abc12/log.txt': 'http://log.txt.temp.url',
             'outputs/test-job-abc12/output1.csv': 'http://output1.csv.temp.url',
             'outputs/test-job-abc12/output2.csv': 'http://output2.csv.temp.url'
@@ -58,7 +56,6 @@ class SparkJobServiceGetOutputFilesTempUrlsTest(TestSparkJobService):
             }
         })
         self.mock_logger.debug.assert_called_once_with('Got temporary URLs for 3 output files for job "test-job-abc12"')
-        self.mock_storage_adapter.get_temp_url_for_each_file.assert_called_once_with(
-            'kubernetes',
+        self.mock_storage_service.get_temp_url_for_each_file.assert_called_once_with(
             'outputs/test-job-abc12/'
         )

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_test.py
@@ -9,7 +9,7 @@ from PiezoWebApp.src.services.spark_job.i_spark_job_namer import ISparkJobNamer
 from PiezoWebApp.src.services.spark_job.spark_job_service import SparkJobService
 from PiezoWebApp.src.services.spark_job.validation.i_manifest_populator import IManifestPopulator
 from PiezoWebApp.src.services.spark_job.validation.i_validation_service import IValidationService
-from PiezoWebApp.src.services.storage.adapters.i_storage_adapter import IStorageAdapter
+from PiezoWebApp.src.services.storage.i_storage_service import IStorageService
 
 NAMESPACE = 'default'
 
@@ -22,13 +22,13 @@ class TestSparkJobService(TestCase):
         self.mock_logger = mock.create_autospec(Logger)
         self.mock_manifest_populator = mock.create_autospec(IManifestPopulator)
         self.mock_spark_job_namer = mock.create_autospec(ISparkJobNamer)
-        self.mock_storage_adapter = mock.create_autospec(IStorageAdapter)
+        self.mock_storage_service = mock.create_autospec(IStorageService)
         self.mock_validation_service = mock.create_autospec(IValidationService)
         self.test_service = SparkJobService(
             self.mock_kubernetes_adapter,
             self.mock_logger,
             self.mock_manifest_populator,
             self.mock_spark_job_namer,
-            self.mock_storage_adapter,
+            self.mock_storage_service,
             self.mock_validation_service
         )

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_tidy_jobs_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_tidy_jobs_test.py
@@ -23,8 +23,7 @@ class SparkJobServiceGetJobStatusTest(TestSparkJobService):
         response = self.test_service.tidy_jobs()
         # Assert
         self.mock_kubernetes_adapter.read_namespaced_pod_log.assert_called_once_with('job-driver', NAMESPACE)
-        self.mock_storage_adapter.set_contents_from_string.assert_called_once_with('kubernetes',
-                                                                                   'outputs/job/log.txt',
+        self.mock_storage_service.set_contents_from_string.assert_called_once_with('outputs/job/log.txt',
                                                                                    'Log\nMessage')
         self.mock_kubernetes_adapter.delete_namespaced_custom_object.assert_called_once_with(CRD_GROUP,
                                                                                              CRD_VERSION,
@@ -47,7 +46,7 @@ class SparkJobServiceGetJobStatusTest(TestSparkJobService):
         response = self.test_service.tidy_jobs()
         # Assert
         self.mock_kubernetes_adapter.read_namespaced_pod_log.assert_not_called()
-        self.mock_storage_adapter.set_contents_from_string.assert_not_called()
+        self.mock_storage_service.set_contents_from_string.assert_not_called()
         self.mock_kubernetes_adapter.delete_namespaced_custom_object.assert_not_called()
         assert response == {'status': 200,
                             'message': '1 Spark jobs found',
@@ -83,13 +82,12 @@ class SparkJobServiceGetJobStatusTest(TestSparkJobService):
             {"metadata": {"name": "job"}, "status": {"applicationState": {"state": "COMPLETED"}}}
         ]}
         self.mock_kubernetes_adapter.read_namespaced_pod_log.return_value = 'Log\nMessage'
-        self.mock_storage_adapter.set_contents_from_string.side_effect = ApiException(reason='S3 Reason', status=999)
+        self.mock_storage_service.set_contents_from_string.side_effect = ApiException(reason='S3 Reason', status=999)
         # Act
         response = self.test_service.tidy_jobs()
         # Assert
         self.mock_kubernetes_adapter.read_namespaced_pod_log.assert_called_once_with('job-driver', NAMESPACE)
-        self.mock_storage_adapter.set_contents_from_string.assert_called_once_with('kubernetes',
-                                                                                   'outputs/job/log.txt',
+        self.mock_storage_service.set_contents_from_string.assert_called_once_with('outputs/job/log.txt',
                                                                                    'Log\nMessage')
         self.mock_kubernetes_adapter.delete_namespaced_custom_object.assert_not_called()
         assert response == {'status': 200,
@@ -100,7 +98,7 @@ class SparkJobServiceGetJobStatusTest(TestSparkJobService):
                                 'job': {
                                     'job_status': 'COMPLETED',
                                     'error_message': 'Got logs for job "job" but unable to write to '
-                                                     '"outputs/job/log.txt" in bucket "kubernetes": S3 Reason',
+                                                     '"outputs/job/log.txt": S3 Reason',
                                     'error_status_code': 999
                                 }}}
 
@@ -118,8 +116,7 @@ class SparkJobServiceGetJobStatusTest(TestSparkJobService):
         response = self.test_service.tidy_jobs()
         # Assert
         self.mock_kubernetes_adapter.read_namespaced_pod_log.assert_called_once_with('job-driver', NAMESPACE)
-        self.mock_storage_adapter.set_contents_from_string.assert_called_once_with('kubernetes',
-                                                                                   'outputs/job/log.txt',
+        self.mock_storage_service.set_contents_from_string.assert_called_once_with('outputs/job/log.txt',
                                                                                    'Log\nMessage')
         self.mock_kubernetes_adapter.delete_namespaced_custom_object.assert_called_once_with(CRD_GROUP,
                                                                                              CRD_VERSION,

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_write_logs_to_file_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_write_logs_to_file_test.py
@@ -19,13 +19,12 @@ class SparkJobServiceWriteLogsToFileTest(TestSparkJobService):
     def test_write_logs_to_file_logs_and_returns_storage_api_exception_reason(self):
         # Arrange
         self.mock_kubernetes_adapter.read_namespaced_pod_log.return_value = 'Log\nMessage'
-        self.mock_storage_adapter.set_contents_from_string.side_effect = ApiException(reason='S3 Reason', status=999)
+        self.mock_storage_service.set_contents_from_string.side_effect = ApiException(reason='S3 Reason', status=999)
         # Act
         result = self.test_service.write_logs_to_file('test-job')
         # Assert
         self.mock_kubernetes_adapter.read_namespaced_pod_log.assert_called_once_with('test-job-driver', NAMESPACE)
-        expected_message = 'Got logs for job "test-job" but unable to write to "outputs/test-job/log.txt" ' \
-                           'in bucket "kubernetes": S3 Reason'
+        expected_message = 'Got logs for job "test-job" but unable to write to "outputs/test-job/log.txt": S3 Reason'
         self.mock_logger.error.assert_called_once_with(expected_message)
         self.assertDictEqual(result, {'status': 999, 'message': expected_message})
 
@@ -36,9 +35,9 @@ class SparkJobServiceWriteLogsToFileTest(TestSparkJobService):
         result = self.test_service.write_logs_to_file('test-job')
         # Assert
         self.mock_kubernetes_adapter.read_namespaced_pod_log.assert_called_once_with('test-job-driver', NAMESPACE)
-        self.mock_storage_adapter.set_contents_from_string.assert_called_once_with(
-            'kubernetes', 'outputs/test-job/log.txt', 'Log\nMessage')
+        self.mock_storage_service.set_contents_from_string.assert_called_once_with('outputs/test-job/log.txt',
+                                                                                   'Log\nMessage')
         self.assertDictEqual(result, {
-            'message': f'Logs written to "outputs/test-job/log.txt" in bucket "kubernetes"',
+            'message': f'Logs written to "outputs/test-job/log.txt"',
             'status': 200
         })

--- a/piezo_web_app/PiezoWebApp/tests/services/storage/storage_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/storage/storage_service_test.py
@@ -1,0 +1,122 @@
+from logging import Logger
+from unittest import TestCase
+
+import mock
+import pytest
+
+from PiezoWebApp.src.services.storage.adapters.i_storage_adapter import IStorageAdapter
+from PiezoWebApp.src.services.storage.storage_service import StorageService
+from PiezoWebApp.src.utils.configurations import Configuration
+
+
+class TestStorageService(TestCase):
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.mock_logger = mock.create_autospec(Logger)
+        self.mock_storage_adapter = mock.create_autospec(IStorageAdapter)
+
+    def get_test_service(self):
+        configuration = mock.create_autospec(Configuration)
+        configuration.s3_bucket_name = 'test-bucket'
+        configuration.temp_url_expiry_seconds = 10
+        test_service = StorageService(
+            configuration,
+            self.mock_logger,
+            self.mock_storage_adapter
+        )
+        return test_service
+
+    def set_bucket_exists(self):
+        self.mock_storage_adapter.does_bucket_exist.return_value = True
+
+    def test_init_checks_bucket_exists(self):
+        # Arrange
+        self.set_bucket_exists()
+        # Act
+        self.get_test_service()
+        # Assert
+        self.mock_storage_adapter.does_bucket_exist.assert_called_once_with('test-bucket')
+        self.mock_storage_adapter.create_bucket.assert_not_called()
+        self.mock_logger.info.assert_called_once_with(
+            'Bucket "test-bucket" already exists: no need to change')
+
+    def test_init_creates_bucket_if_non_existent(self):
+        # Arrange
+        self.mock_storage_adapter.does_bucket_exist.return_value = False
+        # Act
+        self.get_test_service()
+        # Assert
+        self.mock_storage_adapter.does_bucket_exist.assert_called_once_with('test-bucket')
+        self.mock_storage_adapter.create_bucket.assert_called_once_with('test-bucket')
+        self.mock_logger.info.assert_called_once_with('Created new bucket "test-bucket"')
+
+    def test_get_temp_url_for_each_file_returns_empty_dict_if_no_files(self):
+        # Arrange
+        self.set_bucket_exists()
+        test_service = self.get_test_service()
+        self.mock_storage_adapter.get_all_files.return_value = []
+        # Act
+        result = test_service.get_temp_url_for_each_file('outputs/test-job-abc12/')
+        # Assert
+        self.mock_storage_adapter.get_all_files.assert_called_once_with('test-bucket', 'outputs/test-job-abc12/')
+        self.mock_storage_adapter.generate_temp_url.assert_not_called()
+        assert result == {}
+
+    def test_get_temp_url_for_each_file_returns_file_path_and_url_for_single_file(self):
+        # Arrange
+        self.set_bucket_exists()
+        test_service = self.get_test_service()
+        self.mock_storage_adapter.get_all_files.return_value = ['outputs/test-job-abc12/file1.txt']
+        self.mock_storage_adapter.generate_temp_url.return_value = \
+            'http://s3.com/test-bucket/outputs/test-job-abc12/file1.txt'
+        # Act
+        result = test_service.get_temp_url_for_each_file('outputs/test-job-abc12/')
+        # Assert
+        self.mock_storage_adapter.get_all_files.assert_called_once_with('test-bucket', 'outputs/test-job-abc12/')
+        self.mock_storage_adapter.generate_temp_url.assert_called_once_with(
+            'test-bucket', 'outputs/test-job-abc12/file1.txt', 10, 'GET')
+        self.assertDictEqual(result, {
+            'outputs/test-job-abc12/file1.txt': 'http://s3.com/test-bucket/outputs/test-job-abc12/file1.txt'
+        })
+
+    def test_get_temp_url_for_each_file_returns_file_path_and_url_for_multiple_files(self):
+        # Arrange
+        self.set_bucket_exists()
+        test_service = self.get_test_service()
+        self.mock_storage_adapter.get_all_files.return_value = [
+            'outputs/test-job-abc12/file1.txt',
+            'outputs/test-job-abc12/file2.txt',
+            'outputs/test-job-abc12/file3.txt'
+        ]
+        self.mock_storage_adapter.generate_temp_url.side_effect = [
+            'http://s3.com/test-bucket/outputs/test-job-abc12/file1.txt',
+            'http://s3.com/test-bucket/outputs/test-job-abc12/file2.txt',
+            'http://s3.com/test-bucket/outputs/test-job-abc12/file3.txt'
+        ]
+        # Act
+        result = test_service.get_temp_url_for_each_file('outputs/test-job-abc12/')
+        # Assert
+        self.mock_storage_adapter.get_all_files.assert_called_once_with('test-bucket', 'outputs/test-job-abc12/')
+        self.mock_storage_adapter.generate_temp_url.assert_has_calls([
+            mock.call('test-bucket', 'outputs/test-job-abc12/file1.txt', 10, 'GET'),
+            mock.call('test-bucket', 'outputs/test-job-abc12/file2.txt', 10, 'GET'),
+            mock.call('test-bucket', 'outputs/test-job-abc12/file3.txt', 10, 'GET')
+        ])
+        self.assertDictEqual(result, {
+            'outputs/test-job-abc12/file1.txt': 'http://s3.com/test-bucket/outputs/test-job-abc12/file1.txt',
+            'outputs/test-job-abc12/file2.txt': 'http://s3.com/test-bucket/outputs/test-job-abc12/file2.txt',
+            'outputs/test-job-abc12/file3.txt': 'http://s3.com/test-bucket/outputs/test-job-abc12/file3.txt'
+        })
+
+    def test_set_contents_from_string_calls_adapter_and_logs_size(self):
+        # Arrange
+        self.set_bucket_exists()
+        test_service = self.get_test_service()
+        self.mock_storage_adapter.set_contents_from_string.return_value = 12345
+        # Act
+        test_service.set_contents_from_string('outputs/test-job-abc12/log.txt', 'Message')
+        # Assert
+        self.mock_storage_adapter.set_contents_from_string.assert_called_once_with(
+            'test-bucket', 'outputs/test-job-abc12/log.txt', 'Message'
+        )
+        self.mock_logger.debug.assert_called_once_with('Wrote 12345 bytes to "outputs/test-job-abc12/log.txt"')

--- a/piezo_web_app/PiezoWebApp/tests/utils/configuration_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/utils/configuration_test.py
@@ -16,6 +16,7 @@ class SampleConfigurationCreator:
                              k8s_cluster_config_file,
                              tidy_frequency,
                              s3_endpoint,
+                             s3_bucket_name,
                              s3_secret_name,
                              secrets_dir,
                              temp_url_expiry_seconds):
@@ -43,6 +44,9 @@ class SampleConfigurationCreator:
         template = SampleConfigurationCreator.add_element_to_temp_file(template,
                                                                        "S3Endpoint",
                                                                        s3_endpoint)
+        template = SampleConfigurationCreator.add_element_to_temp_file(template,
+                                                                       "S3BucketName",
+                                                                       s3_bucket_name)
         template = SampleConfigurationCreator.add_element_to_temp_file(template,
                                                                        "S3KeysSecret",
                                                                        s3_secret_name)
@@ -93,6 +97,7 @@ def test_configuration_parses_with_arguments():
                                                                          "Some/Path",
                                                                          "3600",
                                                                          "https://0.0.0.0:0",
+                                                                         "test-bucket",
                                                                          "some_secret",
                                                                          "/etc/secrets/",
                                                                          "600")
@@ -110,6 +115,7 @@ def test_configuration_parses_with_arguments():
     assert configuration.s3_endpoint == "https://0.0.0.0:0"
     assert configuration.s3_host == "0.0.0.0"
     assert configuration.s3_port == 0
+    assert configuration.s3_bucket_name == "test-bucket"
     assert configuration.s3_secrets_name == "some_secret"
     assert configuration.secrets_dir == "/etc/secrets/"
     assert configuration.is_s3_secure is True


### PR DESCRIPTION
Stories covered: https://github.com/ukaea/piezo/issues/115

`S3BucketName` is now a configuration item.

`BotoAdapter` was starting to contain to much business logic, and so the opportunity was taken to refactor: a `StorageService` now sits between the `SparkJobService` and the `BotoAdapter`.

The `StorageService` creates the designated bucket if it does not already exist.

Due to issues with conflicting key sets on the Kubernetes master node, the access key is logged when `run_piezo.py` initialises the application. The secret key is not logged for obvious reasons.

System tests still run fine, except for the first checking Grafana. This is unrelated to the changes made here.