### PR TITLE
Feature/add support for python3 #122

### DIFF
--- a/Spark/Dockerfile
+++ b/Spark/Dockerfile
@@ -1,7 +1,28 @@
 FROM gitlab-registry.cern.ch/db/spark-service/docker-registry/spark:v2.4.0-hadoop3-0.7
 
+
+
+# Install python 3
+# ENV PYTHON_VERSION=3.6 \
+#     PATH=$HOME/.local/bin/:$PATH \
+#     PYTHONUNBUFFERED=1 \
+#     PYTHONIOENCODING=UTF-8 \
+#     LC_ALL=en_US.UTF-8 \
+#     LANG=en_US.UTF-8 \
+#     PIP_NO_CACHE_DIR=off
+
+RUN yum install -y centos-release-scl-rh && \
+    yum-config-manager --enable centos-sclo-rh-testing && \
+    INSTALL_PKGS="rh-python36 rh-python36-python-pip" &&\
+    yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y
+
+ENV PATH="/opt/rh/rh-python36/root/usr/bin:${PATH}"
+
 # Setup for the Prometheus JMX exporter.
 RUN mkdir -p /etc/metrics/conf
+
 # Add the Prometheus JMX exporter Java agent jar for exposing metrics sent to the JmxSink to Prometheus.
 ADD https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.3.1/jmx_prometheus_javaagent-0.3.1.jar /prometheus/
 

--- a/Spark/Dockerfile
+++ b/Spark/Dockerfile
@@ -1,23 +1,14 @@
 FROM gitlab-registry.cern.ch/db/spark-service/docker-registry/spark:v2.4.0-hadoop3-0.7
 
-
-
 # Install python 3
-# ENV PYTHON_VERSION=3.6 \
-#     PATH=$HOME/.local/bin/:$PATH \
-#     PYTHONUNBUFFERED=1 \
-#     PYTHONIOENCODING=UTF-8 \
-#     LC_ALL=en_US.UTF-8 \
-#     LANG=en_US.UTF-8 \
-#     PIP_NO_CACHE_DIR=off
-
 RUN yum install -y centos-release-scl-rh && \
     yum-config-manager --enable centos-sclo-rh-testing && \
     INSTALL_PKGS="rh-python36 rh-python36-python-pip" &&\
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y
-
+    
+# Add python3 to path
 ENV PATH="/opt/rh/rh-python36/root/usr/bin:${PATH}"
 
 # Setup for the Prometheus JMX exporter.

--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -77,6 +77,12 @@ Submit SparkPi Job
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
     [return]  ${response}
 
+Submit SparkPi Job
+    [Arguments]   ${job_name}
+    ${submitbody}=    Create Dictionary   name=${job_name}   language=Python   python_version=3    path_to_main_app_file=s3a://kubernetes/inputs/pi.py    label=systemTest
+    ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
+    [return]  ${response}
+
 Submit SparkPi Job With Label
     [Arguments]   ${job_name}   ${label}
     ${submitbody}=    Create Dictionary   name=${job_name}   language=Python   python_version=2    path_to_main_app_file=s3a://kubernetes/inputs/pi.py    label=${label}

--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -77,7 +77,7 @@ Submit SparkPi Job
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
     [return]  ${response}
 
-Submit SparkPi Job
+Submit SparkPi Python3 Job
     [Arguments]   ${job_name}
     ${submitbody}=    Create Dictionary   name=${job_name}   language=Python   python_version=3    path_to_main_app_file=s3a://kubernetes/inputs/pi.py    label=systemTest
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -79,10 +79,10 @@ Submit Job With 30 Character Name Fails
     Should Be Equal As Strings    ${error}    The following errors were found:\n\"name\" input must obey naming convention: see https://github.com/ukaea/piezo/wiki/WebAppUserGuide#submit-a-job\n
 
 Can Run Python3 Jobs
-    ${response}=    Submit SparkPi Python3 Job    spark-pi
+    ${response}=    Submit SparkPi Python3 Job    spark-pi-py3
     Confirm Ok Response  ${response}
     ${job_name}=    Get Response Job Name   ${response}
-    Should Match Regexp   ${job_name}   spark-pi-[a-z0-9]{5}
+    Should Match Regexp   ${job_name}   spark-pi-py3-[a-z0-9]{5}
     ${message}=   Get Response Data Message   ${response}
     Should Be Equal As Strings    ${message}    Job driver created successfully
     ${finished}=    Wait For Spark Job To Finish        ${job_name}     5 seconds

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -289,3 +289,13 @@ Spark UI Is Accessable While A Spark Job Is Running
     Create Session    spark_ui    ${spark_ui}
     ${ui_response}=   Get Request    spark_ui   /
     Confirm Ok Response   ${ui_response}
+
+Can Run Python3 Jobs
+    ${response}=    Submit SparkPi Python3 Job    spark-pi
+    Confirm Ok Response  ${response}
+    ${job_name}=    Get Response Job Name   ${response}
+    Should Match Regexp   ${job_name}   spark-pi-[a-z0-9]{5}
+    ${message}=   Get Response Data Message   ${response}
+    Should Be Equal As Strings    ${message}    Job driver created successfully
+    ${finished}=    Wait For Spark Job To Finish        ${job_name}     5 seconds
+    Should Be True      ${finished}

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -78,6 +78,16 @@ Submit Job With 30 Character Name Fails
     ${error}=   Get Response Data     ${response}
     Should Be Equal As Strings    ${error}    The following errors were found:\n\"name\" input must obey naming convention: see https://github.com/ukaea/piezo/wiki/WebAppUserGuide#submit-a-job\n
 
+Can Run Python3 Jobs
+    ${response}=    Submit SparkPi Python3 Job    spark-pi
+    Confirm Ok Response  ${response}
+    ${job_name}=    Get Response Job Name   ${response}
+    Should Match Regexp   ${job_name}   spark-pi-[a-z0-9]{5}
+    ${message}=   Get Response Data Message   ${response}
+    Should Be Equal As Strings    ${message}    Job driver created successfully
+    ${finished}=    Wait For Spark Job To Finish        ${job_name}     5 seconds
+    Should Be True      ${finished}
+
 Submit Input Args Job With Arguments Returns Ok Response
     ${response}=    Submit InputArgs Job With Arguments   input-args-test
     Confirm Ok Response  ${response}
@@ -289,13 +299,3 @@ Spark UI Is Accessable While A Spark Job Is Running
     Create Session    spark_ui    ${spark_ui}
     ${ui_response}=   Get Request    spark_ui   /
     Confirm Ok Response   ${ui_response}
-
-Can Run Python3 Jobs
-    ${response}=    Submit SparkPi Python3 Job    spark-pi
-    Confirm Ok Response  ${response}
-    ${job_name}=    Get Response Job Name   ${response}
-    Should Match Regexp   ${job_name}   spark-pi-[a-z0-9]{5}
-    ${message}=   Get Response Data Message   ${response}
-    Should Be Equal As Strings    ${message}    Job driver created successfully
-    ${finished}=    Wait For Spark Job To Finish        ${job_name}     5 seconds
-    Should Be True      ${finished}


### PR DESCRIPTION
Add python3 dependencies into the spark docker image run in each spark job. Includes an extra system test running the spark pi example with python3. Python2 jobs still run as normal.

Installed python version is python 3.6

#122 

## To test
Run system tests