### PR TITLE
Feature/spark ui only on request/#134

### DIFF
--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -105,6 +105,13 @@ Submit Wordcount On Minio Job
     ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
     [return]  ${response}
 
+Submit Wordcount On Minio Job With Spark UI
+    [Arguments]   ${job_name}
+    ${arguments}=   Create List   s3a://kubernetes/inputs/big.txt
+    ${submitbody}=    Create Dictionary   name=${job_name}   language=Python   python_version=2    path_to_main_app_file=s3a://kubernetes/inputs/wordcount.py     label=systemTest      arguments=${arguments}    executors=4   spark_ui=true
+    ${response}=    Post Request With Json Body   /piezo/submitjob    ${submitbody}
+    [return]  ${response}
+
 Tidy jobs
     ${headers}=   Json Header
     Create Session    k8s   ${K8S_ENDPOINT}

--- a/SystemTests/roles/robot/files/k8s_methods.robot
+++ b/SystemTests/roles/robot/files/k8s_methods.robot
@@ -120,7 +120,7 @@ Tidy jobs
 
 
 Wait For Spark Job To Finish
-    [Arguments]    ${job_name}    ${step_size}
+    [Arguments]    ${job_name}
     :For    ${i}    IN RANGE   0    ${JOB_FINISH_CHECK_STEPS}
     \   Sleep     ${JOB_FINISH_CHECK_INTERVAL}
     \   ${response}=   Get Status Of Spark Job   ${job_name}

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -300,6 +300,11 @@ Spark UI From Submission Is Accessible While A Spark Job Is Running
     ${ui_response}=   Get Request    spark_ui   /
     Confirm Ok Response   ${ui_response}
 
+Spark UI From Submission Is Not Returned When Not Requested
+    ${response}=    Submit Wordcount On Minio Job   wordcount-ui-job
+    Confirm Ok Response  ${response}
+    Dictionary Should Not Contain Key   ${response}   spark_ui
+
 Spark UI From Status Is Accessible While A Spark Job Is Running
     ${response}=    Submit Wordcount On Minio Job With Spark UI   wordcount-ui-job
     Confirm Ok Response  ${response}
@@ -310,3 +315,12 @@ Spark UI From Status Is Accessible While A Spark Job Is Running
     Create Session    spark_ui    ${spark_ui}
     ${ui_response}=   Get Request    spark_ui   /
     Confirm Ok Response   ${ui_response}
+
+Spark UI From Status Is Not Available If Not Requested On Submission
+    ${response}=    Submit Wordcount On Minio Job   wordcount-ui-job
+    Confirm Ok Response  ${response}
+    ${job_name}=    Get Response Job Name   ${response}
+    Sleep   20 seconds
+    ${response}=  Get Status Of Spark Job    ${job_name}
+    ${spark_ui}=    Get Response Spark UI   ${response}
+    Should Be Equal As Strings    ${spark_ui}    Unavailable

--- a/SystemTests/roles/robot/files/piezo.robot
+++ b/SystemTests/roles/robot/files/piezo.robot
@@ -169,7 +169,6 @@ Status Of Job Contains All Information
     Dictionary Should Contain Key   ${data}   submission_attempts
     Dictionary Should Contain Key   ${data}   last_submitted
     Dictionary Should Contain Key   ${data}   terminated
-    Dictionary Should Contain Key   ${data}   spark_ui
     Dictionary Should Contain Key   ${data}   error_messages
 
 Job Can Use Data And Code On S3 And Write Back Results
@@ -293,7 +292,7 @@ Output Files Provides Temporary URLs
     Should Be True   ${line_count} > 0
 
 Spark UI From Submission Is Accessible While A Spark Job Is Running
-    ${response}=    Submit Wordcount On Minio Job   wordcount-ui-job
+    ${response}=    Submit Wordcount On Minio Job With Spark UI   wordcount-ui-job
     Confirm Ok Response  ${response}
     ${spark_ui}=    Get Response Spark UI   ${response}
     Sleep   20 seconds
@@ -302,7 +301,7 @@ Spark UI From Submission Is Accessible While A Spark Job Is Running
     Confirm Ok Response   ${ui_response}
 
 Spark UI From Status Is Accessible While A Spark Job Is Running
-    ${response}=    Submit Wordcount On Minio Job   wordcount-ui-job
+    ${response}=    Submit Wordcount On Minio Job With Spark UI   wordcount-ui-job
     Confirm Ok Response  ${response}
     ${job_name}=    Get Response Job Name   ${response}
     Sleep   20 seconds

--- a/piezo_web_app/PiezoWebApp/example_validation_rules.json
+++ b/piezo_web_app/PiezoWebApp/example_validation_rules.json
@@ -65,6 +65,10 @@
     "default": "spark"
   },
   {
+    "input_name": "spark_ui",
+    "classification": "Optional"
+  },
+  {
     "input_name": "name",
     "classification": "Required"
   },

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
@@ -64,3 +64,7 @@ class IKubernetesAdapter(metaclass=ABCMeta):
     @abstractmethod
     def read_namespaced_deployment(self, name, namespace):
         pass
+
+    @abstractmethod
+    def read_namespaced_pod_status(self, name, namespace):
+        pass

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
@@ -60,3 +60,7 @@ class IKubernetesAdapter(metaclass=ABCMeta):
     @abstractmethod
     def read_namespaced_pod_log(self, driver_name, namespace):
         pass
+
+    @abstractmethod
+    def read_namespaced_deployment(self, name, namespace):
+        pass

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/i_kubernetes_adapter.py
@@ -62,9 +62,5 @@ class IKubernetesAdapter(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def read_namespaced_deployment(self, name, namespace):
-        pass
-
-    @abstractmethod
     def read_namespaced_pod_status(self, name, namespace):
         pass

--- a/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
+++ b/piezo_web_app/PiezoWebApp/src/services/kubernetes/kubernetes_adapter.py
@@ -57,8 +57,11 @@ class KubernetesAdapter(IKubernetesAdapter):
     def get_namespaced_custom_object(self, group, version, namespace, plural, name):
         return self._custom_connection.get_namespaced_custom_object(group, version, namespace, plural, name)
 
+    def list_namespaced_custom_object(self, group, version, namespace, plural, **kwargs):
+        return self._custom_connection.list_namespaced_custom_object(group, version, namespace, plural, **kwargs)
+
     def read_namespaced_pod_log(self, driver_name, namespace):
         return self._core_connection.read_namespaced_pod_log(driver_name, namespace)
 
-    def list_namespaced_custom_object(self, group, version, namespace, plural, **kwargs):
-        return self._custom_connection.list_namespaced_custom_object(group, version, namespace, plural, **kwargs)
+    def read_namespaced_pod_status(self, name, namespace):
+        return self._core_connection.read_namespaced_pod_status(name, namespace)

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_ui_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_ui_service.py
@@ -10,7 +10,7 @@ class SparkUiService:
         self._logger = logger
 
     def get_spark_ui_url(self, job_name):
-        url = self._spark_ui_adapter.create_ui_url(job_name)
+        url = self._spark_ui_adapter.create_ui_url(job_name) if self.does_spark_ui_exist(job_name) else "Unavailable"
         return url
 
     def expose_spark_ui(self, job_name):

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_ui_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_ui_service.py
@@ -28,6 +28,11 @@ class SparkUiService:
         return url
 
     def delete_spark_ui_components(self, job_name, body):
+        if not self.does_spark_ui_exist(job_name):
+            msg = f'No need to delete Spark UI for "{job_name}": does not exist.'
+            self._logger.debug(msg)
+            return msg
+
         proxy_name = f'{job_name}-ui-proxy'
         ingress_name = f'{proxy_name}-ingress'
         error = False
@@ -52,3 +57,10 @@ class SparkUiService:
         msg = f'Spark ui deleted successfully for job "{job_name}"' if error is False \
             else f'Error deleting spark ui for job "{job_name}", please contact an administrator'
         return msg
+
+    def does_spark_ui_exist(self, job_name):
+        try:
+            self._kubernetes_adapter.read_namespaced_pod_status(job_name, NAMESPACE)
+            return True
+        except Exception:
+            return False

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_ui_service.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/spark_ui_service.py
@@ -63,4 +63,5 @@ class SparkUiService:
             self._kubernetes_adapter.read_namespaced_pod_status(job_name, NAMESPACE)
             return True
         except Exception:
+            self._logger.debug(f'Spark UI not found for job "{job_name}"')
             return False

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/argument_validator.py
@@ -3,6 +3,7 @@ import string
 
 from PiezoWebApp.src.models.spark_job_validation_result import ValidationResult
 from PiezoWebApp.src.utils.str_helper import is_str_empty
+from PiezoWebApp.src.utils.str_helper import str2bool
 
 
 def validate(key, value, validation_rule):
@@ -22,6 +23,8 @@ def validate(key, value, validation_rule):
         return _validate_byte_quantity(key, value, validation_rule)
     if key in ["arguments"]:
         return ValidationResult(True, None, value)
+    if key in ["spark_ui"]:
+        return _validate_bool(key, value)
     raise ValueError(f"Unexpected argument {key}")
 
 
@@ -143,3 +146,17 @@ def _validate_byte_quantity(key, value, validation_rule):
             f'"{key}" input must be in range [{validation_rule.minimum}m, {validation_rule.maximum}m]',
             None
         )
+
+
+def _validate_bool(key, value):
+    error_result = ValidationResult(False, f'"{key}" input must be "true" or "false"', None)
+    if isinstance(value, bool):
+        bool_value = value
+    elif isinstance(value, str):
+        try:
+            bool_value = str2bool(value)
+        except ValueError:
+            return error_result
+    else:
+        return error_result
+    return ValidationResult(True, None, bool_value)

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/delete_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/delete_job_test.py
@@ -129,7 +129,6 @@ class DeleteJobIntegrationTest(BaseIntegrationTest):
         self.mock_logger.error.assert_any_call('Trying to delete spark ui ingress resulted in exception: '
                                                '(Failed to delete ingress)\nReason: None\n')
 
-
     @gen_test
     def test_trying_to_delete_non_existent_job_returns_404_with_reason(self):
         # Arrange

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/delete_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/delete_job_test.py
@@ -35,6 +35,7 @@ class DeleteJobIntegrationTest(BaseIntegrationTest):
         kubernetes_response = {'status': 'Success'}
         self.mock_k8s_adapter.delete_namespaced_custom_object.return_value = kubernetes_response
         self.mock_k8s_adapter.delete_options.return_value = {"api_version": "version", "other_values": "values"}
+        self.mock_k8s_adapter.read_namespaced_pod_status.return_value = True
         # Act
         response_body, response_code = yield self.send_request(body)
         # Assert
@@ -63,6 +64,7 @@ class DeleteJobIntegrationTest(BaseIntegrationTest):
         kubernetes_response = {'status': 'Success'}
         self.mock_k8s_adapter.delete_namespaced_custom_object.return_value = kubernetes_response
         self.mock_k8s_adapter.delete_options.return_value = {"api_version": "version", "other_values": "values"}
+        self.mock_k8s_adapter.read_namespaced_pod_status.return_value = True
         # Act
         response_body, response_code = yield self.send_request(body)
         # Assert
@@ -87,6 +89,7 @@ class DeleteJobIntegrationTest(BaseIntegrationTest):
         kubernetes_response = {'status': 'Success'}
         self.mock_k8s_adapter.delete_namespaced_custom_object.return_value = kubernetes_response
         self.mock_k8s_adapter.delete_options.return_value = {"api_version": "version", "other_values": "values"}
+        self.mock_k8s_adapter.read_namespaced_pod_status.return_value = True
         self.mock_k8s_adapter.delete_namespaced_deployment.side_effect = ApiException('Failed to delete proxy')
         self.mock_k8s_adapter.delete_namespaced_service.side_effect = ApiException('Failed to delete service')
         self.mock_k8s_adapter.delete_namespaced_ingress.side_effect = ApiException('Failed to delete ingress')

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/example_validation_rules.json
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/example_validation_rules.json
@@ -65,6 +65,10 @@
     "default": "spark"
   },
   {
+    "input_name": "spark_ui",
+    "classification": "Optional"
+  },
+  {
     "input_name": "name",
     "classification": "Required"
   },

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
@@ -274,7 +274,6 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             }
         })
 
-
     @gen_test
     def test_spark_ui_is_returned_as_unavailable_and_errors_logged_when_initialisation_fails(self):
         # Arrange

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
@@ -135,8 +135,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'status': 'success',
             'data': {
                 'message': 'Job driver created successfully',
-                'job_name': 'test-python-job-abcd1',
-                'spark_ui': 'http://1.1.1.1:1/proxy:test-python-job-abcd1-ui-svc:4040'
+                'job_name': 'test-python-job-abcd1'
             }
         })
 
@@ -244,10 +243,37 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'status': 'success',
             'data': {
                 'message': 'Job driver created successfully',
+                'job_name': 'test-scala-job-abcd1'
+            }
+        })
+
+    @gen_test
+    def test_spark_ui_is_returned_when_requested(self):
+        # Arrange
+        body = {
+            'name': 'test-scala-job',
+            'language': 'Scala',
+            'path_to_main_app_file': '/path_to/file',
+            'main_class': 'main.class',
+            'spark_ui': 'true'
+        }
+        self.mock_k8s_adapter.get_namespaced_custom_object.side_effect = ApiException(status=999)
+        kubernetes_response = {'metadata': {'name': 'test_scala_job'}}
+        self.mock_k8s_adapter.create_namespaced_custom_object.return_value = kubernetes_response
+        self.mock_storage_adapter.access_protocol.return_value = 's3a'
+        # Act
+        with patch('uuid.uuid4', return_value='abcd1234-ef56-gh78-ij90'):
+            response_body, response_code = yield self.send_request(body)
+        # Assert
+        self.assertDictEqual(response_body, {
+            'status': 'success',
+            'data': {
+                'message': 'Job driver created successfully',
                 'job_name': 'test-scala-job-abcd1',
                 'spark_ui': 'http://1.1.1.1:1/proxy:test-scala-job-abcd1-ui-svc:4040'
             }
         })
+
 
     @gen_test
     def test_spark_ui_is_returned_as_unavailable_and_errors_logged_when_initialisation_fails(self):
@@ -257,7 +283,8 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'language': 'Scala',
             'path_to_main_app_file': '/path_to/file',
             'main_class': 'main.class',
-            'arguments': ["1000"]
+            'arguments': ["1000"],
+            'spark_ui': 'true'
         }
         self.mock_k8s_adapter.get_namespaced_custom_object.side_effect = ApiException(status=999)
         kubernetes_response = {'metadata': {'name': 'test_scala_job'}}
@@ -382,8 +409,7 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
             'status': 'success',
             'data': {
                 'message': 'Job driver created successfully',
-                'job_name': 'test-python-job-abcd1',
-                'spark_ui': 'http://1.1.1.1:1/proxy:test-python-job-abcd1-ui-svc:4040'
+                'job_name': 'test-python-job-abcd1'
             }
         })
 

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_job_service_submit_job_test.py
@@ -25,7 +25,8 @@ class SparkJobServiceSubmitJobTest(TestSparkJobService):
             'metadata': {
                 'namespace': NAMESPACE,
                 'name': 'test-spark-job-abcd1234',
-                'language': 'example-language'
+                'language': 'example-language',
+                'spark_ui': 'false'
             }
         }
         self.mock_manifest_populator.build_manifest.return_value = manifest
@@ -50,15 +51,15 @@ class SparkJobServiceSubmitJobTest(TestSparkJobService):
         self.assertDictEqual(result, {
             'status': StatusCodes.Okay.value,
             'message': 'Job driver created successfully',
-            'job_name': 'test-spark-job-abcd1234',
-            'spark_ui': 'some_url'
+            'job_name': 'test-spark-job-abcd1234'
         })
 
     def test_submit_job_calls_spark_ui_service_correctly_to_expose_ui(self):
         # Arrange
         body = {
             'name': 'test-spark-job',
-            'language': 'example-language'
+            'language': 'example-language',
+            'spark_ui': 'true'
         }
         self.mock_validation_service.validate_request_keys.return_value = ValidationResult(True, "", None)
         self.mock_validation_service.validate_request_values.return_value = ValidationResult(True, "", body)
@@ -74,7 +75,8 @@ class SparkJobServiceSubmitJobTest(TestSparkJobService):
         # Arrange
         body = {
             'name': 'test-spark-job',
-            'language': 'example-language'
+            'language': 'example-language',
+            'spark_ui': 'true'
         }
         self.mock_validation_service.validate_request_keys.return_value = ValidationResult(True, "", None)
         self.mock_validation_service.validate_request_values.return_value = ValidationResult(True, "", body)

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_ui_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_ui_service_test.py
@@ -58,6 +58,7 @@ class TestSparkUiService:
         # Arrange
         job_name = "test_job"
         body = "body"
+        self.mock_k8s_adapter.read_namespaced_pod_status.return_value = True
         # Act
         self.test_ui_service.delete_spark_ui_components(job_name, body)
         # Assert
@@ -71,6 +72,7 @@ class TestSparkUiService:
         # Arrange
         job_name = None
         body = "body"
+        self.mock_k8s_adapter.read_namespaced_pod_status.return_value = True
         # Act
         self.test_ui_service.delete_spark_ui_components(job_name, body)
         # Assert

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_ui_service_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/spark_ui_service_test.py
@@ -95,3 +95,22 @@ class TestSparkUiService:
         self.mock_k8s_adapter.delete_namespaced_ingress.assert_called_once_with("None-ui-proxy-ingress",
                                                                                 NAMESPACE,
                                                                                 body)
+
+    def test_get_spark_ui_url_returns_url_for_ui_when_it_exist(self):
+        # Arrange
+        job_name = "test-job"
+        self.mock_k8s_adapter.read_namespaced_pod_status.return_value = True
+        # Act
+        url = self.test_ui_service.get_spark_ui_url(job_name)
+        # Assert
+        assert url == 'ui.url'
+
+    def test_get_spark_ui_url_returns_unavailable_if_ui_does_not_exist(self):
+        # Arrange
+        job_name = "test-job"
+        self.mock_k8s_adapter.read_namespaced_pod_status.side_effect = ApiException("UI not found")
+        # Act
+        url = self.test_ui_service.get_spark_ui_url(job_name)
+        # Assert
+        assert url == 'Unavailable'
+        self.mock_logger.debug.assert_any_call('Spark UI not found for job "test-job"')


### PR DESCRIPTION
Spark UI is now only available when requested when submitting a job. When requesting the status of the job or deleting a job the existence of the UI is checked first before performing any actions. If not found then `Unavailable` is returned in the status and deletion processes are skipped returning a message that it wasn't present. When the spark UI is present deletion and the url are returned as normal.

#134