### PR TITLE
Feature/add tolerations to executor pods #137

### DIFF
--- a/piezo_web_app/PiezoWebApp/example_validation_rules.json
+++ b/piezo_web_app/PiezoWebApp/example_validation_rules.json
@@ -65,6 +65,26 @@
     "default": "spark"
   },
   {
+    "input_name": "executor_toleration_key",
+    "classification": "Fixed",
+    "default": "piezoRestriction"
+  },
+  {
+    "input_name": "executor_toleration_operation",
+    "classification": "Fixed",
+    "default": "Equal"
+  },
+  {
+    "input_name": "executor_toleration_value",
+    "classification": "Fixed",
+    "default": "executors"
+  },
+  {
+    "input_name": "executor_toleration_effect",
+    "classification": "Fixed",
+    "default": "NoSchedule"
+  },
+  {
     "input_name": "name",
     "classification": "Required"
   },

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
@@ -32,6 +32,13 @@ class ManifestPopulator(IManifestPopulator):
         self._spec_driver_label_version = self._validation_rules.get_default_value_for_key("spark_version")
         self._spec_driver_service_account = self._validation_rules.get_default_value_for_key("service_account")
         self._spec_executor_instances = self._validation_rules.get_default_value_for_key("executors")
+        self._spec_executor_toleration_key = self._validation_rules.get_default_value_for_key("executor_toleration_key")
+        self._spec_executor_toleration_operation = \
+            self._validation_rules.get_default_value_for_key("executor_toleration_operation")
+        self._spec_executor_toleration_value = \
+            self._validation_rules.get_default_value_for_key("executor_toleration_value")
+        self._spec_executor_toleration_effect = \
+            self._validation_rules.get_default_value_for_key("executor_toleration_effect")
         self._spec_executor_cores = self._validation_rules.get_default_value_for_key("executor_cores")
         self._spec_executor_memory = self._validation_rules.get_default_value_for_key("executor_memory")
         self._spec_executor_label_version = self._validation_rules.get_default_value_for_key("spark_version")
@@ -100,10 +107,10 @@ class ManifestPopulator(IManifestPopulator):
                         "labels": {
                             "version": self._spec_executor_label_version},
                         "tolerations": {
-                            "key": "piezoRestriction",
-                            "operator": "Equal",
-                            "value": "executors",
-                            "effect": "NoSchedule"},
+                            "key": self._spec_executor_toleration_key,
+                            "operator": self._spec_executor_toleration_operation,
+                            "value": self._spec_executor_toleration_value,
+                            "effect": self._spec_executor_toleration_effect},
                         "envSecretKeyRefs": {
                             "AWS_ACCESS_KEY_ID": {
                                 "name": self._secret_name,

--- a/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
+++ b/piezo_web_app/PiezoWebApp/src/services/spark_job/validation/manifest_populator.py
@@ -99,6 +99,11 @@ class ManifestPopulator(IManifestPopulator):
                         "memory": self._spec_executor_memory,
                         "labels": {
                             "version": self._spec_executor_label_version},
+                        "tolerations": {
+                            "key": "piezoRestriction",
+                            "operator": "Equal",
+                            "value": "executors",
+                            "effect": "NoSchedule"},
                         "envSecretKeyRefs": {
                             "AWS_ACCESS_KEY_ID": {
                                 "name": self._secret_name,

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/example_validation_rules.json
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/example_validation_rules.json
@@ -65,6 +65,26 @@
     "default": "spark"
   },
   {
+    "input_name": "executor_toleration_key",
+    "classification": "Fixed",
+    "default": "piezoRestriction"
+  },
+  {
+    "input_name": "executor_toleration_operation",
+    "classification": "Fixed",
+    "default": "Equal"
+  },
+  {
+    "input_name": "executor_toleration_value",
+    "classification": "Fixed",
+    "default": "executors"
+  },
+  {
+    "input_name": "executor_toleration_effect",
+    "classification": "Fixed",
+    "default": "NoSchedule"
+  },
+  {
     "input_name": "name",
     "classification": "Required"
   },

--- a/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/integration_tests/submit_job_test.py
@@ -106,6 +106,12 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
                     'instances': 1,
                     'memory': '512m',
                     'labels': {'version': '2.4.0'},
+                    'tolerations': {
+                        'key': 'piezoRestriction',
+                        'operator': 'Equal',
+                        'value': 'executors',
+                        'effect': 'NoSchedule'
+                    },
                     'envSecretKeyRefs': {
                         'AWS_ACCESS_KEY_ID': {
                             'name': 'secret',
@@ -215,6 +221,12 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
                     'instances': 1,
                     'memory': '512m',
                     'labels': {'version': '2.4.0'},
+                    'tolerations': {
+                        'key': 'piezoRestriction',
+                        'operator': 'Equal',
+                        'value': 'executors',
+                        'effect': 'NoSchedule'
+                    },
                     'envSecretKeyRefs': {
                         'AWS_ACCESS_KEY_ID': {
                             'name': 'secret',
@@ -352,6 +364,12 @@ class TestSubmitJobIntegration(BaseIntegrationTest):
                     'instances': 10,
                     'memory': '4096m',
                     'labels': {'version': '2.4.0'},
+                    'tolerations': {
+                        'key': 'piezoRestriction',
+                        'operator': 'Equal',
+                        'value': 'executors',
+                        'effect': 'NoSchedule'
+                    },
                     'envSecretKeyRefs': {
                         'AWS_ACCESS_KEY_ID': {
                             'name': 'secret',

--- a/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/manifest_populator_test.py
+++ b/piezo_web_app/PiezoWebApp/tests/services/spark_job/validation/manifest_populator_test.py
@@ -42,6 +42,10 @@ class TestTemplatePopulator(unittest.TestCase):
                 'executors': 1,
                 'executor_cores': 1,
                 'executor_memory': "512m",
+                'executor_toleration_key': 'piezoRestriction',
+                'executor_toleration_operation': 'Equal',
+                'executor_toleration_value': 'executors',
+                'executor_toleration_effect': 'NoSchedule',
                 'label': None
             }[input_name]
         self.test_populator = ManifestPopulator(mock_configuration, mock_validation_ruleset)
@@ -114,6 +118,12 @@ class TestTemplatePopulator(unittest.TestCase):
                     "instances": "1",
                     "memory": "512m",
                     "labels": {"version": "2.4.0"},
+                    'tolerations': {
+                        'key': 'piezoRestriction',
+                        'operator': 'Equal',
+                        'value': 'executors',
+                        'effect': 'NoSchedule'
+                    },
                     "envSecretKeyRefs": {
                         "AWS_ACCESS_KEY_ID": {
                             "name": "secret",
@@ -195,6 +205,12 @@ class TestTemplatePopulator(unittest.TestCase):
                     "instances": "1",
                     "memory": "512m",
                     "labels": {"version": "2.4.0"},
+                    'tolerations': {
+                        'key': 'piezoRestriction',
+                        'operator': 'Equal',
+                        'value': 'executors',
+                        'effect': 'NoSchedule'
+                    },
                     "envSecretKeyRefs": {
                         "AWS_ACCESS_KEY_ID": {
                             "name": "secret",
@@ -269,6 +285,12 @@ class TestTemplatePopulator(unittest.TestCase):
                     "instances": 1,
                     "memory": "512m",
                     "labels": {"version": "2.4.0"},
+                    'tolerations': {
+                        'key': 'piezoRestriction',
+                        'operator': 'Equal',
+                        'value': 'executors',
+                        'effect': 'NoSchedule'
+                    },
                     "envSecretKeyRefs": {
                         "AWS_ACCESS_KEY_ID": {
                             "name": "secret",


### PR DESCRIPTION
Add tolerations to the executor pods created through Piezo. These will then be allowed to run on any node with matching taints while other pods will not. By keeping a selection of nodes just for executors this should ensure that the system doesn't hang waiting for resources to run spark jobs. Note before the tolerations will have any affect a taint must be applied to the nodes that are to be designated as executor nodes. This taint is applied by running: `kubectl taint {node name}  piezoRestriction=executors:NoSchedule` (other taints could be used but you would also need to change the default values in the validation rules to match.)

#137 

## THIS BRANCH HAS NOT HAD SYSTEM TESTS RUN AGAINST IT AND SHOULD NOT BE MERGED UNTIL THEY HAVE SUCCESSFULLY RUN WITH IT